### PR TITLE
Feature/rtt 73 import template download endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ Or in app/settings/*
 
     ENFORCE_STAFF_SSO_ENABLED=True on
     ENFORCE_STAFF_SSO_ENABLED=False off
+
+## Management commands
+### Import template
+To generate a import `.xlsx` template run the following command:
+
+`python manage.py generate_import_template`
+
+The following file will be created in the root of the project directory:
+
+`rtt_enquiries_import_template.xlsx`
+
 ## More useful info
 
 If you already have the app container running and want to restart, you can use this:

--- a/app/enquiries/management/commands/generate_import_template.py
+++ b/app/enquiries/management/commands/generate_import_template.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand, no_translations
+from django.conf import settings
+from openpyxl import Workbook
+from app.enquiries.utils import generate_import_template
+
+class Command(BaseCommand):
+    help = '''this command generates a .XLSX template for users to enter enquiries
+     and manually import them as a CSVfile'''
+
+    def handle(self, *args, **options):
+        generate_import_template(settings.IMPORT_TEMPLATE_FILENAME)
+        self.stdout.write(self.style.SUCCESS(f'Successfully generated the template file to: "{OUTPUT_FILE_NAME}"'))
+

--- a/app/enquiries/ref_data.py
+++ b/app/enquiries/ref_data.py
@@ -70,7 +70,7 @@ class PrimarySector(models.TextChoices):
     DEFAULT = "DEFAULT", _("----")
     ADVANCED_ENG = "ADVANCED_ENG", _("Advanced Engineering")
     AEROSPACE = "AEROSPACE", _("Aerospace")
-    AGRICULTURE = "AGRICULTURE,", _("Agriculture, Horticulture, Fisheries and Pets")
+    AGRICULTURE = "AGRICULTURE", _("Agriculture, Horticulture, Fisheries and Pets")
     AIRPORTS = "AIRPORTS", _("Airports")
     AUTOMOTIVE = "AUTOMOTIVE", _("Automotive")
     CHEMICALS = "CHEMICALS", _("Chemicals")

--- a/app/enquiries/ref_data.py
+++ b/app/enquiries/ref_data.py
@@ -426,6 +426,23 @@ class DatahubProjectStatus(models.TextChoices):
     DELAYED = "DELAYED", _("Delayed")
 
 
+IMPORT_COL_NAMES = [
+    "enquirer_first_name",
+    "enquirer_last_name",
+    "enquirer_job_title",
+    "enquirer_email",
+    "enquirer_phone",
+    "enquirer_request_for_call",
+    "country",
+    "company_name",
+    "primary_sector",
+    "company_hq_address",
+    "website",
+    "investment_readiness",
+    "enquiry_text",
+    "notes",
+]
+
 MAP_ENQUIRY_FIELD_TO_REF_DATA = {
     "enquiry_stage": EnquiryStage,
     "investment_readiness": InvestmentReadiness,

--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -3,12 +3,7 @@ import pytz
 import random
 from openpyxl import Workbook, load_workbook
 
-<<<<<<< HEAD
 from datetime import date, datetime
-=======
-from datetime import date
-
->>>>>>> add spreadsheet download endpoint and tests
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.forms.models import model_to_dict
@@ -18,11 +13,8 @@ from rest_framework import status
 from unittest import mock
 
 import app.enquiries.ref_data as ref_data
-<<<<<<< HEAD
 import app.enquiries.tests.utils as test_utils
-=======
 import app.enquiries.views as enquiry_views
->>>>>>> add spreadsheet download endpoint and tests
 
 from app.enquiries.models import Enquiry, Enquirer
 from app.enquiries.tests.factories import (

--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -1,8 +1,14 @@
 import pytest
 import pytz
 import random
+from openpyxl import Workbook, load_workbook
 
+<<<<<<< HEAD
 from datetime import date, datetime
+=======
+from datetime import date
+
+>>>>>>> add spreadsheet download endpoint and tests
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.forms.models import model_to_dict
@@ -12,7 +18,11 @@ from rest_framework import status
 from unittest import mock
 
 import app.enquiries.ref_data as ref_data
+<<<<<<< HEAD
 import app.enquiries.tests.utils as test_utils
+=======
+import app.enquiries.views as enquiry_views
+>>>>>>> add spreadsheet download endpoint and tests
 
 from app.enquiries.models import Enquiry, Enquirer
 from app.enquiries.tests.factories import (
@@ -322,6 +332,7 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
         country_display_name = get_display_name(ref_data.Country, enquiry.country)
         self.assertContains(response, enquiry_stage_display_name)
         self.assertContains(response, country_display_name)
+    
     def test_helper_login(self):
         result = self.login()
         self.assertEqual(result, True)
@@ -410,3 +421,33 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
         data = response.data
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(data["count"], 0)
+
+    def test_import_template(self):
+        """Tests that the dynamically generated .XLSX template is accessible has the correct format.
+        The spreadsheet has multiple sheets with the 'enquiries' sheet used to capture user input.
+        All other sheets are populate with the apps ref_data.py
+        """
+        import io
+        import tempfile
+
+        response = self.client.get(reverse("import-template"))
+        content = response.content
+
+        wb = load_workbook(io.BytesIO(content))
+        sheet = wb.active
+        for row in sheet.values:
+            for i, val in enumerate(row):
+                self.assertEqual(
+                    val,
+                    ref_data.IMPORT_COL_NAMES[i],
+                    msg="should match expected column value",
+                )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(
+            enquiry_views.ImportTemplateDownloadView.CONTENT_TYPE,
+            response.get("Content-Type"),
+            msg=f"Should have content type: {enquiry_views.ImportTemplateDownloadView.CONTENT_TYPE}",
+        )
+        self.assertIn(
+            settings.IMPORT_TEMPLATE_FILENAME, response.get("Content-Disposition")
+        )

--- a/app/enquiries/utils.py
+++ b/app/enquiries/utils.py
@@ -1,4 +1,10 @@
 from django.conf import settings
+from openpyxl import Workbook
+
+import app.enquiries.ref_data as ref_data
+from app.enquiries.models import Enquirer, Enquiry
+
+
 
 def get_oauth_payload(request):
     """
@@ -6,3 +12,83 @@ def get_oauth_payload(request):
     (the oauth data is need for authentication with data and other services authenticated via Staff SSO)
     """
     return request.session.get(settings.AUTHBROKER_TOKEN_SESSION_KEY, None)
+
+
+def row_to_enquiry(row: list) -> Enquirer:
+    """
+    Takes an list representing a CSV row and create an Enquiry instance before saving it to the db
+    """
+    enquirer = Enquirer(
+        first_name=row["enquirer_first_name"],
+        last_name=row["enquirer_last_name"],
+        job_title=row["enquirer_job_title"],
+        email=row["enquirer_email"],
+        phone=row["enquirer_phone"],
+        request_for_call=row["enquirer_request_for_call"],
+    )
+
+    # validate enquirer before saving
+    enquirer.full_clean()
+    e = Enquiry(
+        enquirer=enquirer,
+        country=row["country"],
+        company_name=row["company_name"],
+        primary_sector=row["primary_sector"],
+        company_hq_address=row["company_hq_address"],
+        website=row["website"],
+        investment_readiness=row["investment_readiness"],
+        enquiry_text=row["enquiry_text"],
+        notes=row["notes"],
+    )
+
+    # validate enquiry before saving (but exclude enquirer)
+    e.full_clean(["enquirer"])
+
+    # save and associate
+    enquirer.save()
+    e.enquirer = enquirer
+    e.save()
+    return e
+
+
+def generate_import_template(file_obj):
+    """
+    This function generates an .XLSX spreadsheet for use by by IST team to capture enquiries.
+    The main sheet 'enquiries' is the one end users use to capture information.
+    
+    The enquiry sheet columns are listed in:
+    
+        app.enquiries.ref_data.py:IMPORT_COL_NAMES
+
+    enquirer_first_name | enquirer_last_name | enquirer_job_title | enquirer_email | enquirer_phone | enquirer_request_for_call | country | company_name | primary_sector | company_hq_address | website | investment_readiness | enquiry_text | notes
+    
+    The additional sheets list valid options (i.e. Country names etc) which enable end users to implement their own form of validation.
+
+    The fields for these sheets are also listed in ref_data.py
+
+    """
+    ENTRY_SHEET_NAME = "enquiries"
+
+    book = Workbook()
+
+    references = [
+        ref_data.Country,
+        ref_data.EnquiryStage,
+        ref_data.HowDidTheyHear,
+        ref_data.InvestmentReadiness,
+        ref_data.PrimarySector,
+        ref_data.RequestForCall,
+    ]
+
+    # setup enquiries sheet
+    current_sheet = book.active
+    current_sheet.title = ENTRY_SHEET_NAME
+    current_sheet.append(ref_data.IMPORT_COL_NAMES)
+
+    # append sheets containing ref data
+    for ref in references:
+        current_sheet = book.create_sheet(f"REF_{ref.__name__}")
+        for choice in ref.choices:
+            row = [str(v) for v in choice]
+            current_sheet.append(row)
+    book.save(file_obj)

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -206,6 +206,7 @@ STATIC_ROOT = os.path.join(APP_ROOT, 'enquiries', 'static')
 # App specific settings
 CHAR_FIELD_MAX_LENGTH = 255
 ENQUIRIES_PER_PAGE = env.int('ENQUIRIES_PER_PAGE', default=10)
+IMPORT_TEMPLATE_FILENAME = 'rtt_enquiries_import_template.xlsx'
 
 # Data Hub settings
 # TODO: Access token can be removed once SSO is integrated as it comes from SSO directly

--- a/app/urls.py
+++ b/app/urls.py
@@ -29,6 +29,11 @@ urlpatterns = [
     path("enquiry/", views.EnquiryCreateView.as_view(), name="enquiry-create"),
     path("enquiries/", views.EnquiryListView.as_view(), name="enquiry-list"),
     path(
+        "enquiries/template/",
+        views.ImportTemplateDownloadView.as_view(),
+        name="import-template",
+    ),
+    path(
         "enquiries/<int:pk>/", views.EnquiryDetailView.as_view(), name="enquiry-detail"
     ),
     path(
@@ -39,4 +44,3 @@ urlpatterns = [
 
 if settings.FEATURE_FLAGS["ENFORCE_STAFF_SSO_ON"]:
     urlpatterns.append(path("auth/", include("authbroker_client.urls")),)
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       - .:/usr/src/app
     command: celery worker -A app -l info -Q celery -B
     network_mode: "host"
+    depends_on:
+      - redis
 
   redis:
     image: redis:3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ Markdown==3.1.1
 MarkupSafe==1.1.1
 mohawk==0.3.4
 more-itertools==8.0.2
+openpyxl==3.0.3
 packaging==19.2
 parso==0.5.1
 pexpect==4.7.0


### PR DESCRIPTION
This PR adds the Import spreadsheet (.xlsx) template endpoint which allows IST users to download a template where they can manually enter enquiries as a team.

The main business case for this is that a large proportion of enquiries (roughly 50%) come via LinkedIn which users can only export as a CSV file. Also this matches the users existing workflow.

User workflow using the solution:
1. Download the template
2. User enters enquiries into the spreadsheet
3. User exports the enquiries as .CSV
4. User uploads the file into the enquiries tool.

Some of this functionality overlaps with PR-17 so ideally this would be merged first

The ticket can be found here: https://uktrade.atlassian.net/browse/RTT-73

The UI for this feature will be implemented in a separate PR (https://uktrade.atlassian.net/browse/RTT-55)


This includes a management command, to be run by developer if/when they want to generate a template locally to generate a .csv for local development/testing (in my case I created this command to save our BA from having to copy and paste of our valid option from the Git repo manually).