### PR TITLE
Fix button label

### DIFF
--- a/app/enquiries/templates/enquiry_list.html
+++ b/app/enquiries/templates/enquiry_list.html
@@ -17,11 +17,11 @@
                 <article>
                     <header class="collection-header">
                         <!-- TODO: Add filter controls and data to header -->
-                        <div class="collection-header__row">
+                        <div class="collection-header__top-row">
                             <div class="collection-header__intro">
                                 <span class="big-number-of-enquiries">{{ count }}</span> enquiries
                                 <a href="{% url 'import-enquiries' %}"
-                                    class="add-enquiries-button govuk-button govuk-button--secondary"
+                                    class="import-enquiries-button govuk-button govuk-button--secondary"
                                     data-module="govuk-button">
                                     Import enquiries
                                 </a>
@@ -30,19 +30,14 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="collection-header__page-number">
-                            <span class="header-page-number">Page {{ current_page }} of {{ page_range|length }}</span>
-                        </div>
-                        {% if count != 0 %}
-                            <div class="collection-header__download">
-                                {% if count == 1 %}
-                                    <span class="download-message">You can now download this 1 enquiry</span>
-                                {% else %}
-                                    <span class="download-message">You can now download these {{ count }} enquiries</span>
-                                {% endif %}
-                                <button onclick="window.location.href = `{% url 'export-enquiries' %}`" class="govuk-button download-enquiries-button">Download</button>
+                        <div class="collection-header__row">
+                            <div class="header-page-number-container">
+                                <span class="header-page-number">Page {{ current_page }} of {{ page_range|length }}</span>
                             </div>
-                        {% endif %}
+                            <div class="download-button-container">
+                                <button onclick="window.location.href = `{% url 'export-enquiries' %}`" class="govuk-button download-enquiries-button">Download all</button>
+                            </div>
+                        </div>
                     </header>
                     <ol class="entity-list">
                         {% for obj in results %}

--- a/frontend/sass/_enquiry_list.scss
+++ b/frontend/sass/_enquiry_list.scss
@@ -81,7 +81,7 @@ $govuk-assets-path: '/static/assets/';
     font-size: 1.5rem;
 }
 
-.collection-header__row {
+.collection-header__top-row {
     border-bottom: 5px solid black;
 }
 
@@ -89,23 +89,20 @@ $govuk-assets-path: '/static/assets/';
     margin-top: govuk-spacing(6);
 }
 
-.collection-header__page-number {
+.collection-header__row {
+    display: flex;
     padding: govuk-spacing(3) 0;
     border-bottom: 1px solid #6f777b;
+    margin-right: 0;
 }
 
 .filters-column {
     padding: 0;
 }
 
-.add-enquiries-button {
+.import-enquiries-button {
     float: right;
-}
-
-.collection-header__download {
-    display: flex;
-    padding: govuk-spacing(3) 0;
-    border-bottom: 1px solid #6f777b;
+    margin-bottom: 0;
 }
 
 .download-enquiries-button {
@@ -113,6 +110,10 @@ $govuk-assets-path: '/static/assets/';
     margin-bottom: 0;
 }
 
-.download-message {
-    margin: 0.5rem 0;
+.header-page-number-container {
+    padding: 0.5rem 0;
+}
+
+.download-button-container {
+    margin-left: auto;
 }


### PR DESCRIPTION
## Change description
Removes the misleading download text as we show you can download <num> enquiries but this number changes when filters are applied. By default download exports all enquiries so the text is removed.