### PR TITLE
Fix pagination in combination with filters

### DIFF
--- a/app/enquiries/templates/enquiry_list.html
+++ b/app/enquiries/templates/enquiry_list.html
@@ -52,21 +52,21 @@
                 <ol class="pagination__list">
                     {%if previous is not None %}
                         <li class="pagination__list-item">
-                            <a class="pagination__link" href="{{ previous }}">Previous</a>
+                            <a class="pagination__link" href="{% url 'enquiry-list' %}?{% query_params_with_previous_page query_params current_page %}">Previous</a>
                         </li>
                     {%endif%}
 
                     {% for page in page_range %}
                         {% if page|stringformat:"s" == current_page %}
-                            <a class="pagination__link" href="{% url 'enquiry-list' %}?page={{ page }}"><li class="pagination__list-item pagination__list-item-current">{{ page }}</li></a>
+                            <a class="pagination__link" href="{% url 'enquiry-list' %}?{% query_params_with_pagination query_params page %}"><li class="pagination__list-item pagination__list-item-current">{{ page }}</li></a>
                         {% else %}
-                            <a class="pagination__link" href="{% url 'enquiry-list' %}?page={{ page }}"><li class="pagination__list-item">{{ page }}</li></a>
+                            <a class="pagination__link" href="{% url 'enquiry-list' %}?{% query_params_with_pagination query_params page %}"><li class="pagination__list-item">{{ page }}</li></a>
                         {% endif %}
                     {% endfor %}
 
                     {%if next is not None %}
                         <li class="pagination__list-item">
-                            <a class="pagination__link" href="{{ next }}">Next</a>
+                            <a class="pagination__link" href="{% url 'enquiry-list' %}?{% query_params_with_next_page query_params current_page page_range|length %}">Next</a>
                         </li>
                     {%endif%}
                 </ol>

--- a/app/enquiries/templatetags/enquiries_extras.py
+++ b/app/enquiries/templatetags/enquiries_extras.py
@@ -91,3 +91,31 @@ def query_params_has_value(value, param_key, query_params):
 @register.simple_tag
 def query_params_value_selected(value, param_key, query_params, text='selected'):
     return f' {text}' if str(value) in query_params.getlist(param_key) else ''
+
+
+@register.simple_tag
+def query_params_with_pagination(query_params, page):
+    filter_params = '&'.join([f"{key}={value}" for key, value in query_params.items() if key != "page"])
+
+    if page and filter_params:
+        return f"page={page}&{filter_params}"
+    elif filter_params:
+        return filter_params
+    else:
+        return f"page={page}"
+
+
+@register.simple_tag
+def query_params_with_previous_page(query_params, current_page):
+    if current_page > 1:
+        current_page = current_page - 1
+
+    return query_params_with_pagination(query_params, current_page)
+
+
+@register.simple_tag
+def query_params_with_next_page(query_params, current_page, total_pages):
+    if current_page < total_pages:
+        current_page = int(current_page) + 1
+
+    return query_params_with_pagination(query_params, current_page)


### PR DESCRIPTION
## Change description

Both pagination and filters use query parameters to provide variables
to backend. They both individually work ok but the parameters gets
overwritten if used in combination. Eg apply some filters and select
a particular page from the list of results. In this case once a page
is selected then existing query parameters gets overwritten with the
selected page and because of this filters also gets cleared.

The fix is to append the variables instead of overwriting them which
is implemented using custom template tags.

This PR fixes https://github.com/uktrade/enquiry-mgmt-tool/issues/46
