### PR TITLE
Fix company name filter not showing full search term

### DIFF
--- a/app/enquiries/templates/partials/enquiry_filters.html
+++ b/app/enquiries/templates/partials/enquiry_filters.html
@@ -40,7 +40,7 @@
     <label class="govuk-label" for="company_name__icontains">
       Company name
     </label>
-    <input class="govuk-input" id="company_name__icontains" name="company_name__icontains" type="search" value={{query_params.company_name__icontains}}>
+    <input class="govuk-input" id="company_name__icontains" name="company_name__icontains" type="search" value="{{query_params.company_name__icontains}}">
   </div>
   <div class="govuk-form-group">
     <label class="govuk-label" for="enquirer__email">


### PR DESCRIPTION
## Change description

If the company name search is performed with multiple words separated
by space then upon fetching the results only the first word is shown
in the search field. The results themselves are correct except that
only first word is shown in the search field.

Eg if we search for `testing company` then after fetching results the search term is shown as `testing`

This is just due to not enclosing input field value in double quotes.

This PR fixes https://github.com/uktrade/enquiry-mgmt-tool/issues/80
