### PR TITLE
Fix a bug with the consent fields

### DIFF
--- a/app/enquiries/templates/enquiry_detail.html
+++ b/app/enquiries/templates/enquiry_detail.html
@@ -126,14 +126,16 @@
                         Consent (email)
                     </dt>
                     <dd class="govuk-summary-list__value">
-                        {% if enquiry.email_consent.value %}{{ 'Yes' }}{% else %}{{ 'No' }}{% endif %}</dd>
+                        {{ enquiry.enquirer.email_consent|yesno|capfirst }}
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">
                         Consent (telephone)
                     </dt>
                     <dd class="govuk-summary-list__value">
-                        {% if enquiry.phone_consent.value %}{{ 'Yes' }}{% else %}{{ 'No' }}{% endif %}</dd>
+                        {{ enquiry.enquirer.phone_consent|yesno|capfirst }}
+                    </dd>
                 </div>
             </dl>
         </div>

--- a/app/enquiries/templates/enquiry_edit.html
+++ b/app/enquiries/templates/enquiry_edit.html
@@ -260,14 +260,25 @@
                 <input type="hidden" name="enquirer" value="{{ enquiry.enquirer.id }}">
 
             </div>
-
-            <button class="govuk-button" data-module="govuk-button" type="submit">Save and return</button>
-            <button onclick="window.location.href=`{% url 'enquiry-detail' enquiry.id %}`" type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button">Cancel</button>
-
-            <button onclick="window.location.href=`{% url 'enquiry-delete' enquiry.id %}`" class="enquiry-delete__button govuk-button govuk-button--secondary" type="button">Delete enquiry</button>
-
+            <input
+                type="submit"
+                class="govuk-button"
+                data-module="govuk-button"
+                value="Save and return"
+             />
+            <a
+                href={% url 'enquiry-detail' enquiry.id %}
+                class="govuk-button govuk-button--secondary"
+            >
+                Cancel
+            </a>
+            <a
+                href={% url 'enquiry-delete' enquiry.id %}
+                class="govuk-button govuk-button--secondary"
+            >
+                Delete enquiry
+            </a>
         </form>
-
     </main>
 </div>
 

--- a/app/enquiries/templates/snippets/enquiry_field_boolean_select.html
+++ b/app/enquiries/templates/snippets/enquiry_field_boolean_select.html
@@ -3,12 +3,14 @@
     <label class="govuk-label" for="{{ field }}">
         {{ instance|get_field_verbose_name:field }}
     </label>
-    <select class="govuk-select" id={{ field }} name={{ field }}>
-        <option value="yes" {% if instance|get_field_value:field %} selected{% endif %}>
-            Yes
-        </option>
-        <option value="no" {% if not instance|get_field_value:field %} selected{% endif %}>
-            No
-        </option>
-    </select>
+    {% with value=instance|get_field_value:field %}
+        <select class="govuk-select" id={{ field }} name={{ field }}>
+            <option value="{{ True }}" {{ value|yesno:'selected,'}}>
+                Yes
+            </option>
+            <option value="{{ False }}" {{ value|yesno:',selected'}}>
+                No
+            </option>
+        </select>
+    {% endwith %}
 </div>


### PR DESCRIPTION
Both consent fields showed No regardless of the real value
on the details page and they were always set to Yes by the edit
form, regardless of the selected value.