### PR TITLE
Remove npm build commands from web.sh

### DIFF
--- a/web.sh
+++ b/web.sh
@@ -4,9 +4,6 @@
 
 set  -xe
 
-# Compile css
-npm rebuild node-sass && npm install && npm run sass
-
 ./manage.py migrate --noinput
 
 gunicorn app.wsgi --config app/gunicorn.py


### PR DESCRIPTION
Deployments are currently failing as having the following commands in the `web.sh` script is causing npm to build twice. 
`npm rebuild node-sass && npm install && npm run sass`

This PR removes these commands from the script as npm is already built as part of the node.js buildpack.

TODO: add `npm run sass` as part of npm being built.