### PR TITLE
Add postinstall and build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "test": "cypress open",
     "sass": "gulp",
-    "sass:watch": "gulp && gulp sass:watch"
+    "sass:watch": "gulp && gulp sass:watch",
+    "postinstall": "npm run sass",
+    "build": "echo 'hello'",
+    "postbuild": "echo 'hello again'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In order to build sass after npm packages are installed by the node.js buildpack, I have added a `postinstall` command to `package.json`.

To test whether `npm run build` is called by the buildpack I have also added an echo which would run after this command.