### PR TITLE
Add node version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "gulp-sass": "^4.0.2",
     "gulp-sourcemaps": "^2.6.5",
     "moment": "^2.24.0"
+  },
+  "engines": {
+    "node": "12.17.0"
   }
 }


### PR DESCRIPTION
I have added configuration for `engines` in `package.json` to specify the node version. This will hopefully fix a deployment issue where gulp is not found and therefore sass cannot be built.