### PR TITLE
Add gulp as standard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "homepage": "https://github.com/uktrade/enquiry-mgmt-tool#readme",
   "dependencies": {
-    "govuk-frontend": "^3.5.0"
+    "govuk-frontend": "^3.5.0",
+    "gulp": "^4.0.2"
   },
   "devDependencies": {
     "cypress": "^4.4.0",


### PR DESCRIPTION
This is the 4th PR which is attempting to run `npm run sass` after `npm install` is run from the node buildpack. 

When building on Jenkins, it appears that `gulp` is not recognised ([logs here](https://jenkins.ci.uktrade.digital/job/ci-pipeline/42987/console)). I believe this may be because gulp is only listed as a devDependency, so this PR adds gulp as a dependency in package.json so that it is hopefully picked up by `npm install` during the build.