### PR TITLE
Add gulp-sass and gulp-sourcemaps to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "homepage": "https://github.com/uktrade/enquiry-mgmt-tool#readme",
   "dependencies": {
     "govuk-frontend": "^3.5.0",
-    "gulp": "^4.0.2"
+    "gulp": "^4.0.2",
+    "gulp-sass": "^4.0.2",
+    "gulp-sourcemaps": "^2.6.5"
   },
   "devDependencies": {
     "cypress": "^4.4.0",


### PR DESCRIPTION
In addition to adding gulp in the previous PR (#118) it appears `gulp-sass` and `gulp-sourcemaps` are also needed as dependencies in order to successfully build sass.