### PR TITLE
Add del as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/uktrade/enquiry-mgmt-tool#readme",
   "dependencies": {
+    "del": "^5.1.0",
     "govuk-frontend": "^3.5.0",
     "gulp": "^4.0.2",
     "gulp-sass": "^4.0.2",


### PR DESCRIPTION
Del is required in order to build sass via gulp. Continuation from #118  #119.