### PR TITLE
Cleanup setup for running sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "gulp-sass": "^4.0.2",
     "gulp-sourcemaps": "^2.6.5",
     "moment": "^2.24.0"
-  },
-  "engines": {
-    "node": "13.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "test": "cypress open",
     "sass": "gulp",
     "sass:watch": "gulp && gulp sass:watch",
-    "postinstall": "npm run sass",
-    "build": "echo 'hello'",
-    "postbuild": "echo 'hello again'"
+    "postinstall": "npm run sass"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Following multiple PRs to allow sass to be built when deploying the app, this PR removes two unneeded additions:

1. Two test scripts to check whether `npm build` was run from the cloud foundry node buildpack (it wasn't)
2. Specifying a node version for the buildpack. This has turned out to be unneeded, as the buildpack provides one by default and maintaining a custom version would be an unnecessary burden.

Previous PRs related to this work: #120, #119, #118, #117, #116, #115, #114  