### PR TITLE
Truncate pagination

### DIFF
--- a/app/enquiries/templates/enquiry_list.html
+++ b/app/enquiries/templates/enquiry_list.html
@@ -45,6 +45,7 @@
                         {% endfor %}
                     </ol>
                 </article>
+                {% if total_pages > 1 %}
                 <div class="govuk-grid-row">
                     <nav class="pagination" aria-label="pagination">
                         <ol>
@@ -81,6 +82,7 @@
                         </ol>
                     </nav>
                 </div>
+                {% endif %}
             </div>
         </div>
     </main>

--- a/app/enquiries/templates/enquiry_list.html
+++ b/app/enquiries/templates/enquiry_list.html
@@ -32,7 +32,7 @@
                         </div>
                         <div class="collection-header__row">
                             <div class="header-page-number-container">
-                                <span class="header-page-number">Page {{ current_page }} of {{ pages|length }}</span>
+                                <span class="header-page-number">Page {{ current_page }} of {{ total_pages }}</span>
                             </div>
                             <div class="download-button-container">
                                 <button onclick="window.location.href = `{% url 'export-enquiries' %}`" class="govuk-button download-enquiries-button">Download all</button>
@@ -57,17 +57,22 @@
                                 </li>
                             {%endif%}
 
-                            {% for page_number, current, link in pages %}
-                                    {% if current %}
-                                        <li class="pagination__item pagination__item--active"
-                                            aria-current="page">
-                                            {{ page_number }} 
+                            {% for page in pages %}
+                                    {% if page.current %}
+                                        <li class="pagination__item pagination__item--no-link">
+                                            <a aria-current="page", aria-disabled="true">
+                                                <span class="govuk-visually-hidden">Page</span>{{ page.page_number }} 
+                                            </a>
+                                        </li>
+                                    {% elif page.link %}
+                                        <li class="pagination__item">
+                                            <a class="pagination__link" href="{{ page.link }}" aria-label="Go to page {{ page.page_number }}">
+                                                {{ page.page_number }} 
+                                            </a>
                                         </li>
                                     {% else %}
-                                        <li class="pagination__item">
-                                            <a class="pagination__link" href="{{ link }}">
-                                                {{ page_number }} 
-                                            </a>
+                                        <li class="pagination__item pagination__item--no-link" aria-hidden="true">
+                                            {{ page.page_number }} 
                                         </li>
                                     {% endif %}
                             {% endfor %}

--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -232,7 +232,7 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
         It will be same for all pages except for the last page
         if num_enquiries is not a multiple of page_size
         """
-        num_enquiries = 3
+        num_enquiries = 123
         enquiries = EnquiryFactory.create_batch(num_enquiries)
         ids = [e.id for e in enquiries]
         # reverse the ids because we order by latest first
@@ -250,6 +250,17 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
                 [enq["id"] for enq in response.data["results"]], ids[start:end]
             )
             self.assertEqual(response.data["current_page"], page + 1)
+        
+        response = self.client.get(reverse("enquiry-list"), **headers)
+        pages = response.context["pages"]
+        assert response.context["total_pages"] == 13
+        assert pages[0]["page_number"] == 1
+        assert pages[0]["link"] == (
+            "/enquiries/?page=1"
+        )
+        page_labels = [page["page_number"] for page in pages]
+        assert page_labels == [1, 2, 3, 4, "...", 13]
+
 
         # Ensure accesing the page after the last page should return 404
         response = self.client.get(reverse("enquiry-list"), {"page": total_pages + 1})

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -72,21 +72,27 @@ class PaginationWithPaginationMeta(PageNumberPagination):
     """
 
     def get_paginated_response(self, data):
-        return Response(
-            {
-                "next": self.get_next_link(),
-                "previous": self.get_previous_link(),
-                "count": self.page.paginator.count,
-                "current_page": self.page.number,
-                "results": data,
-                "filter_enquiry_stage": get_enquiry_field("enquiry_stage"),
-                "owners": models.Owner.objects.all().order_by("last_name"),
-                "query_params": self.request.GET,
+        response_data = {
+            "next": self.get_next_link(),
+            "previous": self.get_previous_link(),
+            "count": self.page.paginator.count,
+            "current_page": self.page.number,
+            "results": data,
+            "filter_enquiry_stage": get_enquiry_field("enquiry_stage"),
+            "owners": models.Owner.objects.all().order_by("last_name"),
+            "query_params": self.request.GET,
             "total_pages": len(self.page.paginator.page_range),
-                                               page_number))
-                          for page_number in self.page.paginator.page_range],
-            },
-            template_name="enquiry_list.html",
+            "pages": [{'page_number': page_number,
+                        'current': page_number == self.page.number,
+                        'link': replace_query_param(
+                                            self.request.get_full_path(),
+                                            'page',
+                                            page_number)}
+                        for page_number in self.page.paginator.page_range],
+
+            }
+        return Response(
+            truncate_response_data(response_data),
         )
 
     def post(self, request, format=None):
@@ -96,6 +102,57 @@ class PaginationWithPaginationMeta(PageNumberPagination):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+
+def truncate_response_data(response_data, block_size=4):
+    """
+    Truncate the pagination links.
+
+    We don't want to show a link for every page if there are lots of pages. 
+    This replaces page links which are less useful with an ellipsis ('...').
+    """
+    pages = response_data["pages"]
+
+    if len(pages) <= block_size:
+        return response_data
+
+    current_page_num = response_data["current_page"]
+    current_page_index = response_data["current_page"] - 1
+    first_page = pages[0]
+    last_page = pages[-1]
+
+    block_pivot = block_size // 2
+    start_of_current_block = abs(current_page_num - block_pivot)
+    start_of_last_block = last_page["page_number"] - block_size
+    block_start_index = min(
+        start_of_current_block, start_of_last_block, current_page_index,
+    )
+
+    truncated_pages = pages[block_start_index:][:block_size]
+    first_of_truncated_pages_num = truncated_pages[0]["page_number"]
+    last_of_truncated_pages_num = truncated_pages[-1]["page_number"]
+
+    if first_of_truncated_pages_num > 3:
+        truncated_pages = [{"page_number": "..."}] + truncated_pages
+
+    if first_of_truncated_pages_num == 3:
+        truncated_pages = [pages[1]] + truncated_pages
+
+    if first_of_truncated_pages_num > 1:
+        truncated_pages = [first_page] + truncated_pages
+
+    if last_of_truncated_pages_num < last_page["page_number"] - 2:
+        truncated_pages.append({"page_number": "..."})
+
+    if last_of_truncated_pages_num == last_page["page_number"] - 2:
+        truncated_pages.append(pages[-2])
+
+    if last_of_truncated_pages_num < last_page["page_number"]:
+        truncated_pages.append(last_page)
+
+    response_data["pages"] = truncated_pages
+    return response_data
+
 
 
 def is_valid_id(v) -> bool:

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -82,10 +82,7 @@ class PaginationWithPaginationMeta(PageNumberPagination):
                 "filter_enquiry_stage": get_enquiry_field("enquiry_stage"),
                 "owners": models.Owner.objects.all().order_by("last_name"),
                 "query_params": self.request.GET,
-                "pages": [(page_number,
-                           page_number == self.page.number,
-                           replace_query_param(self.request.get_full_path(),
-                                               'page',
+            "total_pages": len(self.page.paginator.page_range),
                                                page_number))
                           for page_number in self.page.paginator.page_range],
             },

--- a/app/settings/djangotest.py
+++ b/app/settings/djangotest.py
@@ -6,7 +6,7 @@ FEATURE_FLAGS = {
     "ENFORCE_STAFF_SSO_ON": True,
 }
 
-REST_FRAMEWORK["PAGE_SIZE"] = 2
+REST_FRAMEWORK["PAGE_SIZE"] = 10
 
 CACHES["default"] = {
     "BACKEND": "django.core.cache.backends.locmem.LocMemCache",

--- a/sass/_pagination.scss
+++ b/sass/_pagination.scss
@@ -9,11 +9,12 @@
 
 .pagination {
     margin-top: govuk-spacing(6);
+    text-align: center;
 
     &__item {
         display: inline-block;
 
-        &--active {
+        &--no-link {
           @include pagination-item-dimensions();
         }
     }
@@ -27,10 +28,6 @@
         
         &:hover {
             background-color: #dee0e2;
-        }
-
-        &--active {
-            background: none;
         }
     }
 }


### PR DESCRIPTION
This PR adds logic to truncate the page numbers returned when a `GET` request is made to `enquiry-list`. This prevents all page numbers showing at the bottom of the enquiry list when there are lots of results. 

The logic itself mirrors what we have in other DIT systems (Data Hub and Market Access). When there are more than 6 pages worth of enquiries, blocks of 4 pages will be returned at a time (related to what page you're on), with the first and last pages always being displayed and other pages being truncated to just an ellipses `...`.

E.g. if there are 7 pages of results: page numbers would be `[1, 2, 3, 4, '...', 7]`.

I have added aria labels to the page numbers and tested this with a screenreader (VoiceOver).

It would be particularly useful to get feedback on the tests, and how the two response objects could possibly be combined.

**Before**
![image](https://user-images.githubusercontent.com/22460823/87297595-9a712680-c500-11ea-868e-3b6ec661738c.png)

**After**
<img width="675" alt="Screenshot 2020-07-13 at 12 02 10" src="https://user-images.githubusercontent.com/22460823/87297648-afe65080-c500-11ea-9d6e-e66b06fd08a0.png">
