### PR TITLE
Add cache-control and X-XSS-Protection headers

### DIFF
--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -745,3 +745,15 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
             num_enquiries -= 1
 
         self.assertEqual(num_enquiries, 0)
+    
+    def test_security_response_headers(self):
+        """
+        Tests that the add_cache_control_header_middleware and
+        Django's security middleware add the correct header 
+        values to any response. 
+
+        Only tested with one path as middleware is applied to all.
+        """
+        response = self.client.get(reverse("enquiry-list"), **headers)
+        assert response['X-XSS-Protection'] == '1; mode=block'
+        assert response["Cache-Control"] == 'max-age=0, no-cache, no-store, must-revalidate, private'

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,0 +1,9 @@
+def add_cache_control_header_middleware(get_response):
+
+    def middleware(request):
+
+        response = get_response(request)
+        response["Cache-Control"] = 'max-age=0, no-cache, no-store, must-revalidate, private'
+        return response
+
+    return middleware

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -217,6 +217,9 @@ STATICFILES_DIRS = [
 # enable the URL and turn on the Test Fixture API.
 ALLOW_TEST_FIXTURE_SETUP = env('ALLOW_TEST_FIXTURE_SETUP', default=None) == 'allow'
 
+# Sets the X-XSS-Protection HTTP header in older browsers
+SECURE_BROWSER_XSS_FILTER = True
+
 # App specific settings
 CHAR_FIELD_MAX_LENGTH = 255
 ENQUIRIES_PER_PAGE = env.int('ENQUIRIES_PER_PAGE', default=10)

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -106,6 +106,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'app.middleware.add_cache_control_header_middleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
The need for setting the `cache-control` and `X-XSS-Protection` headers came out of the recent pen test done on enquiry management. ([Details in this card](https://trello.com/c/E6HGgRrd/63-http-headers-vulnerability)).

This PR sets `X-XSS-Protection` using Django's security middleware and creates a new middleware `add_cache_control_header_middleware` which sets `Cache-Control`. Creating a middleware rather than a mixin was preferable as the middleware applies to every request automatically, whereas a mixin would have to be passed to every view.

**NOTE**
In the report from the pen test they also recommended setting `Pragma: no-cache` in headers, however it has been decided with Mark that this is not necessary as this only applies to HTTP 1.0 requests, which our users' clients would not be using.

**To test**

1. Go to any view 
2. Check that the two headers below appear under Response Headers:
- `Cache-Control: max-age=0, no-cache, no-store, must-revalidate, private`
- `X-XSS-Protection: 1; mode=block`