### PR TITLE
Add data hub project code to enquiry on submit

### DIFF
--- a/app/enquiries/common/datahub_utils.py
+++ b/app/enquiries/common/datahub_utils.py
@@ -527,6 +527,7 @@ def dh_investment_create(request, enquiry, metadata=None):
         enquiry.datahub_project_status = ref_data.DatahubProjectStatus.PROSPECT
         enquiry.date_added_to_datahub = date.today()
         enquiry.enquiry_stage = ref_data.EnquiryStage.ADDED_TO_DATAHUB
+        enquiry.project_code = response["result"]["project_code"]
         enquiry.save()
 
     return response


### PR DESCRIPTION
When an enquiry submitted to Data Hub, an investment project is created in Data Hub using the details from the enquiry. A project code is created as a result of this, which does not currently get fed back into Enquiry Management.

This PR takes the `project_code` from the Data Hub API response, and sets it to be the `project_code` value of the enquiry which was just submitted.

As we currently do not have integrated tests with Data Hub, I have tested this manually by deploying this branch to the development environment. It can be tested there by submitting an enquiry to Data Hub and checking that the project code is automatically added to the enquiry.