### PR TITLE
Capitalise Owner name

### DIFF
--- a/app/enquiries/models.py
+++ b/app/enquiries/models.py
@@ -31,11 +31,11 @@ class Enquirer(models.Model):
 
 class Owner(AbstractUser):
     """
-    Customer user model user by the app. Each Enquiry has an owner.
+    Customer user model used by the app. Each Enquiry has an owner.
     """
 
     def __str__(self):
-        return f"{self.first_name} {self.last_name}"
+        return f"{self.first_name.title()} {self.last_name.title()}"
 
 
 class Enquiry(TimeStampedModel):

--- a/app/enquiries/templates/partials/enquiry_filters.html
+++ b/app/enquiries/templates/partials/enquiry_filters.html
@@ -14,7 +14,7 @@
         </option>
         {% for owner in owners %}
           <option value="{{ owner.id }}" {% query_params_value_selected owner.id 'owner__id' query_params ' selected'  %}>
-            {{ owner.get_full_name }}
+            {{ owner }}
           </option>
         {% endfor %}
       </select>

--- a/app/enquiries/templates/snippets/enquiry_item.html
+++ b/app/enquiries/templates/snippets/enquiry_item.html
@@ -12,7 +12,7 @@
                     <span>{{ enquiry.enquiry_stage }}</span>
                 </div>
                 <div class="entity__badges-item">
-                    <span>{% if enquiry.owner %}{{ enquiry.owner.first_name }} {{ enquiry.owner.last_name }} {%else%} {{ "Unassigned" }}
+                    <span>{% if enquiry.owner %}{{ enquiry.owner.first_name|title }} {{ enquiry.owner.last_name|title }} {%else%} {{ "Unassigned" }}
                         {%endif%}</span>
                 </div>
                 {% if enquiry.country != "----" %}


### PR DESCRIPTION
When demoing the tool to users, when one user logged in on staging her name appeared as lower case across the pages.

To prevent this from happening, this PR adds the `title()` function to the Owner model's `__str__` method, meaning that whenever an owner object is referenced as a string, it will be capitalised. `title()` was used instead of `capitalise()` because this accounts for names with an apostrophe. E.g. O'Reilly.

In the `enquiry_item` template the Owner object itself isn't referenced, but rather the owner value from a dictionary of results, meaning that the `__str__` method can't be called. So the first and last name are 'titilised' directly in this template.

**To test**

Change a user's name to lower case in `test_users.json` and check that it is capitalised in the following areas:
- Filters
- The badge on an enquiry in the list
- Edit an enquiry
- View an enquiry
- Delete an enquiry