### PR TITLE
Make error messages more human-readable

### DIFF
--- a/app/enquiries/common/datahub_utils.py
+++ b/app/enquiries/common/datahub_utils.py
@@ -469,7 +469,7 @@ def dh_investment_create(request, enquiry, metadata=None):
     # check if the user is available in Data Hub
     user_details, error = dh_get_user_details(request, access_token)
     if error:
-        response["errors"].append({"referral_advisor": error})
+        response["errors"].append({"referral_advisor": "Error validating your identity in Data Hub"})
         return response
 
     dh_status = dh_enquiry_readiness(request, access_token, enquiry)
@@ -491,7 +491,7 @@ def dh_investment_create(request, enquiry, metadata=None):
         request, access_token, full_name, company_id
     )
     if error:
-        response["errors"].append({"contact_search": error})
+        response["errors"].append({"contact_search": f"Error while checking company contacts, {str(error)}"})
         return response
 
     primary = not existing_contacts
@@ -499,7 +499,7 @@ def dh_investment_create(request, enquiry, metadata=None):
         request, access_token, enquiry, company_id, primary=primary
     )
     if error:
-        response["errors"].append({"contact_create": error})
+        response["errors"].append({"contact_create": f"Error while creating a new company contact, {str(error)}"})
         return response
 
     contact_id = contact_response["id"]

--- a/app/enquiries/templates/enquiry_detail.html
+++ b/app/enquiries/templates/enquiry_detail.html
@@ -26,14 +26,14 @@
         {% if errors %}
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
             <h2 class="govuk-error-summary__title" id="error-summary-title">
-              There is a problem.
+                There is a problem.
             </h2>
             {% for error in errors %}
                 <div class="govuk-error-summary__body">
                 <ul class="govuk-list govuk-error-summary__list">
                     {% for key,value in error.items %}
                     <li>
-                        <a href="#{{ key }}">{{key }}: {{ value }}</a>
+                        <a href="#{{ key }}">{{ key|title_phrase }}: {{ value }}</a>
                     </li>
                     {% endfor %}
                 </ul>

--- a/app/enquiries/templatetags/enquiries_extras.py
+++ b/app/enquiries/templatetags/enquiries_extras.py
@@ -90,3 +90,8 @@ def query_params_has_value(value, param_key, query_params):
 @register.simple_tag
 def query_params_value_selected(value, param_key, query_params, text='selected'):
     return f' {text}' if str(value) in query_params.getlist(param_key) else ''
+
+@register.filter
+def title_phrase(value):
+    """Converts a snake case key into a title with spaces"""
+    return value.replace("_", " ").title()

--- a/app/enquiries/utils.py
+++ b/app/enquiries/utils.py
@@ -171,3 +171,25 @@ def export_to_csv(qs: QuerySet, fp: typing.IO):
         data = enquiry_to_dict(e)
         output.append(data)
         writer.writerow(data)
+
+
+def parse_error_messages(e):
+    """
+    Take an error and parse the messages in human-readable form.
+
+    Returns a list of error messages
+    Where there are message dictionaries, separates out each message,
+    parsing the keys into sentence case with title capitalisations
+    """
+    response = []
+
+    if hasattr(e, 'message_dict'):
+        for key, value in e.message_dict.items():
+            msg = f'{key.replace("_", " ").title()}:'
+            for v in value:
+                msg += f' {v}'
+            response.append(msg)
+    else:
+        response.append(str(e))
+
+    return response

--- a/sample_env
+++ b/sample_env
@@ -11,12 +11,12 @@ DJANGO_SENTRY_DSN=sentry-dsn
 ENQUIRIES_PER_PAGE=10
 
 # Data Hub variables
-DATA_HUB_METADATA_URL=http://dh-api-mock:8001/metadata
-DATA_HUB_COMPANY_SEARCH_URL=http://dh-api-mock:8001/company/search
-DATA_HUB_CONTACT_SEARCH_URL=http://dh-api-mock:8001/contact/search
-DATA_HUB_CONTACT_CREATE_URL=http://dh-api-mock:8001/contact/create
-DATA_HUB_INVESTMENT_CREATE_URL=http://dh-api-mock:8001/investment/create
-DATA_HUB_ADVISER_SEARCH_URL=http://dh-api-mock:8001/adviser/search
+DATA_HUB_METADATA_URL=http://dh-api-mock:8001/v4/metadata
+DATA_HUB_COMPANY_SEARCH_URL=http://dh-api-mock:8001/v4/search/company
+DATA_HUB_CONTACT_SEARCH_URL=http://dh-api-mock:8001/v3/search/contact
+DATA_HUB_CONTACT_CREATE_URL=http://dh-api-mock:8001/v3/contact
+DATA_HUB_INVESTMENT_CREATE_URL=http://dh-api-mock:8001/v3/investment
+DATA_HUB_ADVISER_SEARCH_URL=http://dh-api-mock:8001/adviser/
 DATA_HUB_WHOAMI_URL=http://dh-api-mock:8001/whoami
 DATA_HUB_FRONTEND=https://datahub/frontend
 DATA_HUB_CREATE_COMPANY_PAGE_URL=https://www.datahub.dev.uktrade.io/companies/create


### PR DESCRIPTION
Updates error messages to make them more human-readable

* updates the CSV upload error message strings:
<img width="1019" alt="Screenshot 2020-07-22 at 16 45 29" src="https://user-images.githubusercontent.com/23265724/88201170-0cebb000-cc3f-11ea-97a5-5a0932f05e72.png">

* creates a 'title_phrase' filter for the dictionary-based error messages in the `enquiry_detail` view
<img width="1097" alt="Screenshot 2020-07-22 at 16 45 43" src="https://user-images.githubusercontent.com/23265724/88201446-5d630d80-cc3f-11ea-9329-c0a9ea351d64.png">

* adds more human explanations to error messages stemming from data-hub upload task
* also brings the `sample_env` for local development up-to-date with api changes