### PR TITLE
Setup middleware tests

### DIFF
--- a/app/enquiries/tests/test_middleware.py
+++ b/app/enquiries/tests/test_middleware.py
@@ -1,0 +1,33 @@
+from django.urls import reverse
+
+import app.enquiries.tests.utils as test_utils
+from app.settings import common
+
+def test_correct_middleware_exists():
+  assert common.MIDDLEWARE == [
+    'django.middleware.security.SecurityMiddleware',
+    'app.middleware.add_cache_control_header_middleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+def test_security_settings_on():
+  assert common.SECURE_BROWSER_XSS_FILTER == True
+
+class CustomMiddlewareTestCase(test_utils.BaseEnquiryTestCase):
+  def setUp(self):
+      super().setUp()
+
+  def test_custom_cache_control_middleware(self):
+    """
+    Tests that the custom middleware add_cache_control_header_middleware
+    adds the correct cache_control header to a response.
+    """
+    headers = {"HTTP_CONTENT_TYPE": "text/html", "HTTP_ACCEPT": "text/html"}
+    response = self.client.get(reverse("index"), **headers)
+    assert response["Cache-Control"] == 'max-age=0, no-cache, no-store, must-revalidate, private'

--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -750,15 +750,3 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
         self.assertIn(
             settings.IMPORT_TEMPLATE_FILENAME, response.get("Content-Disposition")
         )
-
-    def test_security_response_headers(self):
-        """
-        Tests that the add_cache_control_header_middleware and
-        Django's security middleware add the correct header 
-        values to any response. 
-
-        Only tested with one path as middleware is applied to all.
-        """
-        response = self.client.get(reverse("enquiry-list"), **headers)
-        assert response['X-XSS-Protection'] == '1; mode=block'
-        assert response["Cache-Control"] == 'max-age=0, no-cache, no-store, must-revalidate, private'


### PR DESCRIPTION
This PR sets up tests for middleware in `test_middleware.py` and checks tests that: 

1. The correct middleware are in settings
2. That the security setting `SECURE_BROWSER_XSS_FILTER` is turned on 
3. That the custom middleware `add_cache_control_header_middleware` adds the correct response header values

Some of these things were previously tested in `test_views.py` and have been moved to one file for clarity.

The tests don't check that some settings e.g. the `SECURE_HSTS` and `COOKIE` settings are turned on because they rely on an environment variable being `True`, which will vary between environments.