### PR TITLE
Format files with flake8

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,3 @@
 from app.enquiries.celery import app as celery_app
+
+__all__ = ['celery_app']

--- a/app/asgi.py
+++ b/app/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings.common')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.common")
 
 application = get_asgi_application()

--- a/app/enquiries/admin.py
+++ b/app/enquiries/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/app/enquiries/apps.py
+++ b/app/enquiries/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class EnquiriesConfig(AppConfig):
-    name = 'enquiries'
+    name = "enquiries"

--- a/app/enquiries/celery.py
+++ b/app/enquiries/celery.py
@@ -1,12 +1,11 @@
 import os
 from celery import Celery
-from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings.common')
-app = Celery('app')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.common")
+app = Celery("app")
 
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-app.config_from_object('django.conf:settings')
+app.config_from_object("django.conf:settings")
 app.autodiscover_tasks()

--- a/app/enquiries/forms.py
+++ b/app/enquiries/forms.py
@@ -14,7 +14,7 @@ class EnquirerForm(ModelForm):
 
 
 class AutocompleteField(ChoiceField):
-    widget = autocomplete.Select2(url=reverse_lazy('dh-adviser-search'))
+    widget = autocomplete.Select2(url=reverse_lazy("dh-adviser-search"))
 
     # We need to disable deep copying, otherwise setting the choices dynamically
     # won't take effect.
@@ -36,10 +36,10 @@ class EnquiryForm(ModelForm):
         # choices, the field will not be prepopulated with it.
         # The workaround is to add both the initial and the new value as valid
         # choices dynamically.
-        client_relationship_manager_initial = self.initial.get('client_relationship_manager')
-        client_relationship_manager_data = self.data.get('client_relationship_manager')
+        client_relationship_manager_initial = self.initial.get("client_relationship_manager")
+        client_relationship_manager_data = self.data.get("client_relationship_manager")
 
-        self.fields['client_relationship_manager'].choices = (
+        self.fields["client_relationship_manager"].choices = (
             (client_relationship_manager_data, client_relationship_manager_data),
             (client_relationship_manager_initial, client_relationship_manager_initial),
         )

--- a/app/enquiries/management/commands/export_enquiries.py
+++ b/app/enquiries/management/commands/export_enquiries.py
@@ -4,21 +4,24 @@ from django.core.management.base import BaseCommand
 from app.enquiries.models import Enquiry
 import app.enquiries.ref_data as ref_data
 
-OUTPUT_FILE_SLUG = 'ingest_sample'
-OUTPUT_FILE_EXT = '.csv'
+OUTPUT_FILE_SLUG = "ingest_sample"
+OUTPUT_FILE_EXT = ".csv"
+
 
 class Command(BaseCommand):
     """
-    Command is for use by developers to quickly export CSV data so that the upload functionality can be easily tested
+    Command is for use by developers to quickly export CSV data so that the
+    upload functionality can be easily tested.
     """
-    help = 'this command exports enquiries to simple (level) CSV'
+
+    help = "this command exports enquiries to simple (level) CSV"
 
     def handle(self, *args, **options):
         count = 0
         timestamp = datetime.now().strftime("%Y-%m-%dT%H%M%S")
         entries = Enquiry.objects.all().iterator()
-        filename = f'{OUTPUT_FILE_SLUG}_{timestamp}{OUTPUT_FILE_EXT}' 
-        with open(filename, 'w', newline='') as f:
+        filename = f"{OUTPUT_FILE_SLUG}_{timestamp}{OUTPUT_FILE_EXT}"
+        with open(filename, "w", newline="") as f:
             writer = csv.writer(f)
             # write headers
             writer.writerow(ref_data.IMPORT_COL_NAMES)
@@ -39,9 +42,14 @@ class Command(BaseCommand):
                         e.investment_readiness,
                         e.enquiry_stage,
                         e.enquiry_text,
-                        e.notes
+                        e.notes,
                     ]
                 )
                 count += 1
         # writer.save()
-        self.stdout.write(self.style.SUCCESS(f'Successfully exported enquiry to simple (level 1) file: "{filename}"'))
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"""Successfully exported enquiry to simple (level 1)
+            file: "{filename}" """
+            )
+        )

--- a/app/enquiries/management/commands/generate_import_template.py
+++ b/app/enquiries/management/commands/generate_import_template.py
@@ -1,13 +1,17 @@
-from django.core.management.base import BaseCommand, no_translations
+from django.core.management.base import BaseCommand
 from django.conf import settings
-from openpyxl import Workbook
 from app.enquiries.utils import generate_import_template
 
+
 class Command(BaseCommand):
-    help = '''this command generates a .XLSX template for users to enter enquiries
-     and manually import them as a CSVfile'''
+    help = """this command generates a .XLSX template for users to enter enquiries
+     and manually import them as a CSVfile"""
 
     def handle(self, *args, **options):
         generate_import_template(settings.IMPORT_TEMPLATE_FILENAME)
-        self.stdout.write(self.style.SUCCESS(f'Successfully generated the template file to: "{OUTPUT_FILE_NAME}"'))
-
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'Successfully generated the template file to:\
+ "{settings.IMPORT_TEMPLATE_FILENAME}"'
+            )
+        )

--- a/app/enquiries/management/commands/teardowndata.py
+++ b/app/enquiries/management/commands/teardowndata.py
@@ -1,13 +1,15 @@
 from django.core.management.base import BaseCommand
 from app.enquiries.models import Enquiry, Owner
 
+
 class Command(BaseCommand):
     """
-    Command is for use by developers to quickly export CSV data so that the upload functionality can be easily tested
+    Command is for use by developers to quickly export CSV data so that the
+    upload functionality can be easily tested
     """
-    help = 'this command exports enquiries to simple (level) CSV'
+
+    help = "this command exports enquiries to simple (level) CSV"
 
     def handle(self, *args, **options):
         Enquiry.objects.all().delete()
         Owner.objects.all().delete()
-       

--- a/app/enquiries/models.py
+++ b/app/enquiries/models.py
@@ -44,9 +44,7 @@ class Enquiry(TimeStampedModel):
     """
 
     company_name = models.CharField(
-        max_length=MAX_LENGTH,
-        help_text="Name of the company",
-        verbose_name="Company name",
+        max_length=MAX_LENGTH, help_text="Name of the company", verbose_name="Company name"
     )
     enquiry_stage = models.CharField(
         max_length=MAX_LENGTH,

--- a/app/enquiries/models.py
+++ b/app/enquiries/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.contrib.auth.models import User, AbstractUser
+from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
 
@@ -17,7 +17,9 @@ class Enquirer(models.Model):
     last_name = models.CharField(max_length=MAX_LENGTH, verbose_name="Last name")
     job_title = models.CharField(max_length=MAX_LENGTH, verbose_name="Job title")
     email = models.EmailField(max_length=MAX_LENGTH, blank=True, verbose_name="Email")
-    phone_country_code = models.CharField(max_length=5, blank=True, null=True, verbose_name="Telephone country code")
+    phone_country_code = models.CharField(
+        max_length=5, blank=True, null=True, verbose_name="Telephone country code"
+    )
     phone = models.CharField(max_length=MAX_LENGTH, verbose_name="Phone")
     email_consent = models.BooleanField(default=False, verbose_name="Email consent")
     phone_consent = models.BooleanField(default=False, verbose_name="Phone consent")
@@ -61,10 +63,7 @@ class Enquiry(TimeStampedModel):
         help_text="User assigned to the enquiry",
         verbose_name="Owner",
     )
-    enquiry_text = models.TextField(
-        verbose_name="Enquiry text",
-        editable=False,
-    )
+    enquiry_text = models.TextField(verbose_name="Enquiry text", editable=False,)
     investment_readiness = models.CharField(
         max_length=MAX_LENGTH,
         choices=ref_data.InvestmentReadiness.choices,
@@ -92,9 +91,7 @@ class Enquiry(TimeStampedModel):
         default=ref_data.HowDidTheyHear.DEFAULT,
         verbose_name="How did they hear about DIT?",
     )
-    website = models.TextField(
-        blank=True, verbose_name="Website"
-    )
+    website = models.TextField(blank=True, verbose_name="Website")
     primary_sector = models.CharField(
         max_length=MAX_LENGTH,
         choices=ref_data.PrimarySector.choices,
@@ -107,9 +104,7 @@ class Enquiry(TimeStampedModel):
         default=ref_data.IstSector.DEFAULT,
         verbose_name="IST sector",
     )
-    company_hq_address = models.CharField(
-        max_length=MAX_LENGTH, verbose_name="Company HQ address"
-    )
+    company_hq_address = models.CharField(max_length=MAX_LENGTH, verbose_name="Company HQ address")
     country = models.CharField(
         max_length=MAX_LENGTH,
         choices=ref_data.Country.choices,
@@ -123,10 +118,7 @@ class Enquiry(TimeStampedModel):
         verbose_name="Region",
     )
     enquirer = models.ForeignKey(
-        Enquirer,
-        related_name="enquirer",
-        on_delete=models.PROTECT,
-        verbose_name="Enquirer",
+        Enquirer, related_name="enquirer", on_delete=models.PROTECT, verbose_name="Enquirer",
     )
     first_response_channel = models.CharField(
         max_length=MAX_LENGTH,
@@ -221,22 +213,13 @@ class Enquiry(TimeStampedModel):
     # If the Enquiry for the company that already exists in DH then user can assign
     # that company details to below fields when editing an Enquiry
     dh_company_id = models.CharField(
-        max_length=MAX_LENGTH,
-        blank=True,
-        null=True,
-        verbose_name="Company id in Data Hub",
+        max_length=MAX_LENGTH, blank=True, null=True, verbose_name="Company id in Data Hub",
     )
     dh_company_number = models.CharField(
-        max_length=MAX_LENGTH,
-        blank=True,
-        null=True,
-        verbose_name="Company number in Data Hub",
+        max_length=MAX_LENGTH, blank=True, null=True, verbose_name="Company number in Data Hub",
     )
     dh_duns_number = models.CharField(
-        max_length=MAX_LENGTH,
-        blank=True,
-        null=True,
-        verbose_name="Duns number",
+        max_length=MAX_LENGTH, blank=True, null=True, verbose_name="Duns number",
     )
     dh_assigned_company_name = models.CharField(
         max_length=MAX_LENGTH,
@@ -263,11 +246,9 @@ class ReceivedEnquiryCursor(models.Model):
     This model tracks the timestamp and object id of the last item received.
     They are used to fetch the next set of results.
     """
+
     index = models.CharField(
-        max_length=MAX_LENGTH,
-        help_text="Index of the object",
-        blank=True,
-        null=True,
+        max_length=MAX_LENGTH, help_text="Index of the object", blank=True, null=True,
     )
     object_id = models.CharField(
         max_length=MAX_LENGTH,
@@ -281,17 +262,12 @@ class FailedEnquiry(models.Model):
     """
     Model to track failed enquiries when processing the data from AS
     """
+
     index = models.CharField(
-        max_length=MAX_LENGTH,
-        help_text="Index of the object",
-        blank=True,
-        null=True,
+        max_length=MAX_LENGTH, help_text="Index of the object", blank=True, null=True,
     )
     object_id = models.CharField(
-        max_length=MAX_LENGTH,
-        help_text="Id of the failed object",
-        blank=True,
-        null=True,
+        max_length=MAX_LENGTH, help_text="Id of the failed object", blank=True, null=True,
     )
     html_body = models.TextField(blank=True, null=True, verbose_name="HTML body")
     text_body = models.TextField(blank=True, null=True, verbose_name="Text body")

--- a/app/enquiries/ref_data.py
+++ b/app/enquiries/ref_data.py
@@ -21,14 +21,13 @@ class InvestmentReadiness(models.TextChoices):
     )
     SHORTLIST = (
         "SHORTLIST",
-        _(
-            "The UK is on my shortlist. How can the Department for International Trade help me?"
-        ),
+        _("The UK is on my shortlist. How can the Department for International Trade help me?"),
     )
     EXPLORING = (
         "EXPLORING",
         _(
-            "I’m still exploring where to expand my business and would like to know more about the UK’s offer"
+            "I’m still exploring where to expand my business and would like to know more about the\
+ UK’s offer"
         ),
     )
     NOT_READY = "NOT_READY", _("I’m not yet ready to invest. Keep me informed")
@@ -324,6 +323,7 @@ class Country(models.TextChoices):
     YE = "YE", _("Yemen")
     ZM = "ZM", _("Zambia")
     ZW = "ZW", _("Zimbabwe")
+
 
 class Region(models.TextChoices):
     DEFAULT = "DEFAULT", _("----")

--- a/app/enquiries/serializers.py
+++ b/app/enquiries/serializers.py
@@ -1,5 +1,4 @@
 from django.db import transaction
-from drf_writable_nested import WritableNestedModelSerializer
 from rest_framework import serializers
 
 from app.enquiries import models
@@ -14,14 +13,12 @@ class EnquirerDetailSerializer(serializers.ModelSerializer):
 
 
 class EnquirerSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.Enquirer
         fields = "__all__"
 
 
 class OwnerSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = models.Owner
         fields = "__all__"
@@ -32,6 +29,7 @@ class EnquirySerializer(serializers.ModelSerializer):
     Enquiry model serializer mainly used for serializing during
     create, update of Enquiry objects
     """
+
     enquirer = EnquirerSerializer()
 
     class Meta:
@@ -40,7 +38,7 @@ class EnquirySerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         with transaction.atomic():
-            enquirer = validated_data.pop('enquirer')
+            enquirer = validated_data.pop("enquirer")
             enquirer_instance = models.Enquirer.objects.create(**enquirer)
             enquiry = models.Enquiry.objects.create(**validated_data, enquirer=enquirer_instance)
             return enquiry
@@ -52,6 +50,7 @@ class EnquiryDetailSerializer(serializers.ModelSerializer):
     It provides the human readable form for all the choice fields
     in the Enquiry model.
     """
+
     owner = OwnerSerializer()
     enquirer = EnquirerDetailSerializer()
     created = serializers.DateTimeField(format="%d %B %Y")
@@ -73,8 +72,12 @@ class EnquiryDetailSerializer(serializers.ModelSerializer):
     investment_type = serializers.CharField(source="get_investment_type_display")
     estimated_land_date = serializers.DateField(format="%d %B %Y")
     new_existing_investor = serializers.CharField(source="get_new_existing_investor_display")
-    investor_involvement_level = serializers.CharField(source="get_investor_involvement_level_display")
-    specific_investment_programme = serializers.CharField(source="get_specific_investment_programme_display")
+    investor_involvement_level = serializers.CharField(
+        source="get_investor_involvement_level_display"
+    )
+    specific_investment_programme = serializers.CharField(
+        source="get_specific_investment_programme_display"
+    )
     date_added_to_datahub = serializers.DateField(format="%d %B %Y")
     datahub_project_status = serializers.CharField(source="get_datahub_project_status_display")
     project_success_date = serializers.DateField(format="%d %B %Y")

--- a/app/enquiries/tasks.py
+++ b/app/enquiries/tasks.py
@@ -1,13 +1,9 @@
-import json
 import logging
 
-from celery.task import task
 from celery.task.schedules import crontab
 from celery.decorators import periodic_task
 from datetime import datetime
 from django.conf import settings
-from redis import Redis
-from redis.exceptions import ConnectionError
 
 from app.enquiries.common.datahub_utils import dh_fetch_metadata
 from app.enquiries.common.as_utils import fetch_and_process_enquiries
@@ -26,9 +22,8 @@ def refresh_datahub_metadata():
     # set expiry few minutes before next refresh so that we
     # ensure refresh fetch data again
     expiry_secs = settings.DATA_HUB_METADATA_FETCH_INTERVAL_HOURS * 60 * 60 - (5 * 60)
-    dh_metadata = dh_fetch_metadata(expiry_secs=expiry_secs)
+    dh_fetch_metadata(expiry_secs=expiry_secs)
     logging.info(f"Data Hub metadata last refreshed at {datetime.now()}")
-
 
 
 @periodic_task(

--- a/app/enquiries/templatetags/enquiries_extras.py
+++ b/app/enquiries/templatetags/enquiries_extras.py
@@ -46,9 +46,11 @@ field_error_msgs = {
     "phone": "Enquirer phone is required",
 }
 
+
 @register.filter
 def enquiry_field_error_msg(field):
     return field_error_msgs.get(field)
+
 
 @register.filter
 def is_optional(instance, field_name):
@@ -64,12 +66,14 @@ def get_dh_company_url(enquiry):
     if not enquiry.dh_company_id:
         return "#"
 
-    return os.path.join(settings.DATA_HUB_FRONTEND, 'companies', enquiry.dh_company_id)
+    return os.path.join(settings.DATA_HUB_FRONTEND, "companies", enquiry.dh_company_id)
+
 
 def get_instance_field(instance, field_name):
     fields = instance._meta.fields
     target = list(filter(lambda f: f.name == field_name, fields))
     return target[0]
+
 
 @register.filter
 def get_field_verbose_name(instance, field_name):
@@ -115,17 +119,20 @@ def get_date(instance, field_name):
     field = get_instance_field(instance, field_name)
 
     if field.value_from_object(instance):
-        return field.value_from_object(instance).strftime('%Y-%m-%d')
+        return field.value_from_object(instance).strftime("%Y-%m-%d")
     else:
         return None
+
 
 @register.filter
 def query_params_has_value(value, param_key, query_params):
     return str(value) in query_params.get_list(param_key)
 
+
 @register.simple_tag
-def query_params_value_selected(value, param_key, query_params, text='selected'):
-    return f' {text}' if str(value) in query_params.getlist(param_key) else ''
+def query_params_value_selected(value, param_key, query_params, text="selected"):
+    return f" {text}" if str(value) in query_params.getlist(param_key) else ""
+
 
 @register.filter
 def title_phrase(value):

--- a/app/enquiries/tests/factories.py
+++ b/app/enquiries/tests/factories.py
@@ -19,23 +19,18 @@ def get_display_name(refdata_model, item):
     """Get the verbose name from ref_data given the short name"""
     return list(filter(lambda choice: choice[0] == item, refdata_model.choices))[0][1]
 
+
 def get_display_value(ref_data_model, label):
-    text = [
-        value
-        for (choice_label, value) in ref_data_model.choices
-        if choice_label == label
-    ]
+    text = [value for (choice_label, value) in ref_data_model.choices if choice_label == label]
     return text[0] if text else "Not found"
+
 
 def return_display_value(ref_data_model, label):
     """
-    Returns the ref_data option value when given the the ref_data_model option label
+    Returns the ref_data option value when given the the ref_data_model
+    option label.
     """
-    text = [
-        value
-        for (value, choice_label) in ref_data_model.choices
-        if choice_label == label
-    ]
+    text = [value for (value, choice_label) in ref_data_model.choices if choice_label == label]
     return text[0] if text else "Not found"
 
 
@@ -47,6 +42,7 @@ class OwnerFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Owner
+
 
 class EnquirerFactory(factory.django.DjangoModelFactory):
     first_name = factory.Faker("first_name")

--- a/app/enquiries/tests/test_as_integration.py
+++ b/app/enquiries/tests/test_as_integration.py
@@ -1,21 +1,14 @@
-import json
 import random
 import requests_mock
 
 from datetime import datetime
 from django.conf import settings
 from django.forms.models import model_to_dict
-from django.test import Client, TestCase
+from django.test import TestCase
 from faker import Faker
-from unittest import mock
 
 from app.enquiries.models import Enquiry, Enquirer
-from app.enquiries.common.as_utils import (
-    hawk_request,
-    parse_enquiry_email,
-    get_new_investment_enquiries,
-    fetch_and_process_enquiries,
-)
+from app.enquiries.common.as_utils import fetch_and_process_enquiries
 
 faker = Faker()
 
@@ -28,84 +21,89 @@ table_template = """
             <td>Given name</td>
             <td>{first_name}</td>
         </tr>
-   
+
         <tr>
             <td>Family name</td>
             <td>{last_name}</td>
         </tr>
-    
+
         <tr>
             <td>Job title</td>
             <td>CEO</td>
         </tr>
-    
+
         <tr>
             <td>Email address</td>
             <td>{email}</td>
         </tr>
-    
+
         <tr>
             <td>Phone number</td>
             <td>{phone}</td>
         </tr>
-    
+
         <tr>
             <td>Company name</td>
             <td>{company_name}</td>
         </tr>
-    
+
         <tr>
             <td>Company website</td>
             <td>https://example.com</td>
         </tr>
-    
+
         <tr>
             <td>Company HQ address</td>
             <td>Far, far away</td>
         </tr>
-    
+
         <tr>
             <td>Country</td>
             <td>US</td>
         </tr>
-    
+
         <tr>
             <td>Industry</td>
             <td>AEROSPACE</td>
         </tr>
-    
+
         <tr>
-            <td>Which of these best describes how you feel about expanding to the UK?</td>
-            <td>I’m still exploring where to expand my business and would like to know more about the UK’s offer.</td>
+            <td>
+                Which of these best describes how you feel about expanding to the UK?
+            </td>
+            <td>I’m still exploring where to expand my business and would like to know more about\
+ the UK’s offer.</td>
         </tr>
-    
+
         <tr>
             <td>Tell us about your investment</td>
             <td>This is a test message sent via automated tests</td>
         </tr>
-    
+
         <tr>
             <td>Would you like to arrange a call?</td>
             <td>{arrange_call}</td>
         </tr>
-    
+
         <tr>
             <td>When should we call you?</td>
             <td></td>
         </tr>
-    
+
         <tr>
             <td>How did you hear about us?</td>
             <td>LinkedIn</td>
         </tr>
-    
+
         <tr>
             <td>I would like to receive additional information by email</td>
             <td>{email_consent}</td>
         </tr>
-    
+
         <tr>
-            <td>I would like to receive additional information by telephone</td>
+            <td>
+                I would like to receive additional information by telephone
+            </td>
             <td>{phone_consent}</td>
         </tr>
     </table>
@@ -130,12 +128,8 @@ def get_enquiries_data():
         }
 
         arrange_call = random.choice(["yes", "no", "yes", "yes", "no", "yes"])
-        email_consent = random.choice(
-            ["True", "False", "False", "True", "True", "True"]
-        )
-        phone_consent = random.choice(
-            ["True", "False", "False", "True", "True", "True"]
-        )
+        email_consent = random.choice(["True", "False", "False", "True", "True", "True"])
+        phone_consent = random.choice(["True", "False", "False", "True", "True", "True"])
         detail = {
             "company_name": faker.company(),
             "first_name": faker.name(),
@@ -161,7 +155,6 @@ def get_enquiries_data():
 
 
 class ActivityStreamIntegrationTests(TestCase):
-
     def test_fetch_new_enquiries(self):
         """
         Test that fetches sample enquiries data, parses them and creates
@@ -179,13 +172,9 @@ class ActivityStreamIntegrationTests(TestCase):
             for detail in details:
                 if not detail["skip"]:
                     enquiry = model_to_dict(
-                        Enquiry.objects.filter(
-                            company_name=detail["company_name"]
-                        ).first()
+                        Enquiry.objects.filter(company_name=detail["company_name"]).first()
                     )
-                    enquirer = model_to_dict(
-                        Enquirer.objects.get(id=enquiry["enquirer"])
-                    )
+                    enquirer = model_to_dict(Enquirer.objects.get(id=enquiry["enquirer"]))
                     for k, v in detail.items():
                         if k == "arrange_call":
                             v = True if v == "yes" else False
@@ -197,8 +186,5 @@ class ActivityStreamIntegrationTests(TestCase):
                             self.assertEqual(enquirer[k], v)
                 else:
                     self.assertEqual(
-                        Enquiry.objects.filter(
-                            company_name=detail["company_name"]
-                        ).count(),
-                        0,
+                        Enquiry.objects.filter(company_name=detail["company_name"]).count(), 0
                     )

--- a/app/enquiries/tests/test_dh_integration.py
+++ b/app/enquiries/tests/test_dh_integration.py
@@ -1,16 +1,12 @@
 import pytest
-import requests
 import requests_mock
-import time
 
 from datetime import date
 from django.conf import settings
 from django.core.cache import cache
-from django.test import Client, TestCase
+from django.test import TestCase
 from django.test.client import RequestFactory
-from django.urls import reverse
 from requests.exceptions import Timeout
-from rest_framework import status
 from unittest import mock
 from app.enquiries.tests.factories import EnquiryFactory
 
@@ -25,8 +21,7 @@ from app.enquiries.common.datahub_utils import (
 
 
 metadata_test_responses = {
-    endpoint: {"metadata": f"metadata for {endpoint}"}
-    for endpoint in DATA_HUB_METADATA_ENDPOINTS
+    endpoint: {"metadata": f"metadata for {endpoint}"} for endpoint in DATA_HUB_METADATA_ENDPOINTS
 }
 
 
@@ -81,15 +76,11 @@ class DataHubIntegrationTests(TestCase):
         url = settings.DATA_HUB_COMPANY_SEARCH_URL
         req = RequestFactory()
         post_req = req.post("/investment/", {"name": "test"})
-        post_req.session = {
-            settings.AUTHBROKER_TOKEN_SESSION_KEY: {"access_token": "mock_token"}
-        }
+        post_req.session = {settings.AUTHBROKER_TOKEN_SESSION_KEY: {"access_token": "mock_token"}}
         payload = {"name": "test"}
 
         with pytest.raises(Timeout):
-            response = dh_request(
-                post_req, "access_token", "POST", url, payload, timeout=2
-            )
+            dh_request(post_req, "access_token", "POST", url, payload, timeout=2)
 
     @mock.patch("django.core.cache.cache.get")
     def test_dh_fetch_metada_exception(self, mock_cache_get):
@@ -174,9 +165,7 @@ class DataHubIntegrationTests(TestCase):
             m.post(url, status_code=400, json=contact_search_response()["error"])
             expected = contact_search_response()["error"]
 
-            response, error = dh_contact_search(
-                "mock_request", "access_token", "", "company_id"
-            )
+            response, error = dh_contact_search("mock_request", "access_token", "", "company_id")
             self.assertIsNotNone(error)
             self.assertEqual(error["name"], expected["name"])
 
@@ -185,9 +174,7 @@ class DataHubIntegrationTests(TestCase):
         enquiry = EnquiryFactory()
         req = RequestFactory()
         post_req = req.post("/investment/", {"name": "test"})
-        post_req.session = {
-            settings.AUTHBROKER_TOKEN_SESSION_KEY: {"access_token": "mock_token"}
-        }
+        post_req.session = {settings.AUTHBROKER_TOKEN_SESSION_KEY: {"access_token": "mock_token"}}
         with requests_mock.Mocker() as m:
             url = settings.DATA_HUB_WHOAMI_URL
             m.get(url, json={"user": "details"})
@@ -202,9 +189,7 @@ class DataHubIntegrationTests(TestCase):
         enquiry = EnquiryFactory()
         req = RequestFactory()
         post_req = req.post("/investment/", {"name": "test"})
-        post_req.session = {
-            settings.AUTHBROKER_TOKEN_SESSION_KEY: {"access_token": "mock_token"}
-        }
+        post_req.session = {settings.AUTHBROKER_TOKEN_SESSION_KEY: {"access_token": "mock_token"}}
         enquiry.dh_company_id = "1234-2468"
         enquiry.date_added_to_datahub = date.today()
         enquiry.save()
@@ -216,5 +201,6 @@ class DataHubIntegrationTests(TestCase):
             stage = enquiry.get_datahub_project_status_display()
             self.assertEqual(
                 response["errors"][0]["enquiry"],
-                f"Enquiry can only be submitted once, previously submitted on {prev_date}, stage {stage}",
+                f"Enquiry can only be submitted once, previously submitted on {prev_date}, stage\
+ {stage}",
             )

--- a/app/enquiries/tests/test_factories.py
+++ b/app/enquiries/tests/test_factories.py
@@ -1,19 +1,14 @@
 from django.test import TestCase
 
 import app.enquiries.ref_data as ref_data
-from app.enquiries import serializers
-from app.enquiries.tests.factories import (
-    EnquiryFactory,
-    EnquirerFactory,
-    return_display_value,
-)
+from app.enquiries.tests.factories import return_display_value
 
 
 class EnquiriesFactoriesTestCase(TestCase):
     def test_get_display_name(self):
         option = {
             "label": "Awaiting response from Investor",
-            "value": "AWAITING_RESPONSE"
+            "value": "AWAITING_RESPONSE",
         }
         expected = return_display_value(ref_data.EnquiryStage, option["label"])
         self.assertEqual(expected, option["value"])

--- a/app/enquiries/tests/test_filters.py
+++ b/app/enquiries/tests/test_filters.py
@@ -1,26 +1,10 @@
-import pytest
-import pytz
-import random
-import requests
 from bs4 import BeautifulSoup
-from datetime import date
 
-from django.conf import settings
-from django.forms.models import model_to_dict
-from django.test import Client, TestCase
 from django.urls import reverse
 from faker import Faker
-from rest_framework import status
-from unittest import mock
 
 import app.enquiries.ref_data as ref_data
-from app.enquiries.models import Enquiry, Enquirer
 from app.enquiries.tests import utils as test_utils
-from app.enquiries.tests.factories import (
-    EnquiryFactory,
-    get_random_item,
-    get_display_name,
-)
 
 faker = Faker(["en_GB", "en_US", "ja_JP"])
 headers = {"HTTP_CONTENT_TYPE": "text/html", "HTTP_ACCEPT": "text/html"}
@@ -29,19 +13,17 @@ headers = {"HTTP_CONTENT_TYPE": "text/html", "HTTP_ACCEPT": "text/html"}
 class EnquiryViewFiltersTestCase(test_utils.BaseEnquiryTestCase):
     def setUp(self):
         super().setUp()
-        # self.faker = Faker()
-        # self.client = Client()
 
     def test_enquiry_filters_render(self):
         """Test that the search filters render correctly"""
-        # DRF defaults to JSON response so we need to set headers to receive HTML
+        # DRF defaults to JSON response so we need to set headers to
+        # receive HTML
 
         response = self.client.get(reverse("enquiry-list"), **headers)
         soup = BeautifulSoup(response.content, "html.parser")
 
         self.assertIsNotNone(
-            soup.find(attrs={"data-qa": "search-filters"}),
-            msg="should render search filters",
+            soup.find(attrs={"data-qa": "search-filters"}), msg="should render search filters"
         )
 
         # users dropdown
@@ -77,15 +59,13 @@ class EnquiryViewFiltersTestCase(test_utils.BaseEnquiryTestCase):
             self.assertEqual(_label.string.strip(), label)
 
         self.assertIsNotNone(
-            soup.find(id="created__lt"),
-            msg="should render date created before control",
+            soup.find(id="created__lt"), msg="should render date created before control",
         )
         self.assertIsNotNone(
             soup.find(id="created__gt"), msg="should render date created after control",
         )
         self.assertIsNotNone(
-            soup.find(id="company_name__icontains"),
-            msg="should render company_name control",
+            soup.find(id="company_name__icontains"), msg="should render company_name control",
         )
         self.assertIsNotNone(
             soup.find(id="date_added_to_datahub__lt"),
@@ -98,6 +78,4 @@ class EnquiryViewFiltersTestCase(test_utils.BaseEnquiryTestCase):
         self.assertIsNotNone(
             soup.find(id="enquirer__email"), msg="should render enquirer__email control",
         )
-        self.assertIsNotNone(
-            soup.find(id="btn_submit"), msg="should render btn_submit control"
-        )
+        self.assertIsNotNone(soup.find(id="btn_submit"), msg="should render btn_submit control")

--- a/app/enquiries/tests/test_middleware.py
+++ b/app/enquiries/tests/test_middleware.py
@@ -3,31 +3,36 @@ from django.urls import reverse
 import app.enquiries.tests.utils as test_utils
 from app.settings import common
 
+
 def test_correct_middleware_exists():
-  assert common.MIDDLEWARE == [
-    'django.middleware.security.SecurityMiddleware',
-    'app.middleware.add_cache_control_header_middleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-]
+    assert common.MIDDLEWARE == [
+        "django.middleware.security.SecurityMiddleware",
+        "app.middleware.add_cache_control_header_middleware",
+        "whitenoise.middleware.WhiteNoiseMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.common.CommonMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    ]
+
 
 def test_security_settings_on():
-  assert common.SECURE_BROWSER_XSS_FILTER == True
+    assert common.SECURE_BROWSER_XSS_FILTER is True
+
 
 class CustomMiddlewareTestCase(test_utils.BaseEnquiryTestCase):
-  def setUp(self):
-      super().setUp()
+    def setUp(self):
+        super().setUp()
 
-  def test_custom_cache_control_middleware(self):
-    """
+    def test_custom_cache_control_middleware(self):
+        """
     Tests that the custom middleware add_cache_control_header_middleware
     adds the correct cache_control header to a response.
     """
-    headers = {"HTTP_CONTENT_TYPE": "text/html", "HTTP_ACCEPT": "text/html"}
-    response = self.client.get(reverse("index"), **headers)
-    assert response["Cache-Control"] == 'max-age=0, no-cache, no-store, must-revalidate, private'
+        headers = {"HTTP_CONTENT_TYPE": "text/html", "HTTP_ACCEPT": "text/html"}
+        response = self.client.get(reverse("index"), **headers)
+        assert (
+            response["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, private"
+        )

--- a/app/enquiries/tests/test_models.py
+++ b/app/enquiries/tests/test_models.py
@@ -1,6 +1,5 @@
 import pytest
 
-from django.forms.models import model_to_dict
 from django.test import TestCase
 
 from app.enquiries.models import Enquirer, Enquiry

--- a/app/enquiries/tests/test_ping_views.py
+++ b/app/enquiries/tests/test_ping_views.py
@@ -1,13 +1,9 @@
 from unittest import mock
-from django.contrib.auth import get_user_model
 from django.db.utils import OperationalError
 from django.urls import reverse
 from rest_framework import status
 
 import app.enquiries.tests.utils as test_utils
-
-from app.enquiries import models
-from app.enquiries.tests.factories import EnquiryFactory
 
 
 class ServiceHealthCheckTestCase(test_utils.BaseEnquiryTestCase):
@@ -21,9 +17,7 @@ class ServiceHealthCheckTestCase(test_utils.BaseEnquiryTestCase):
         """
         response = self.client.post(reverse("ping"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response._headers["content-type"], ("Content-Type", "text/plain")
-        )
+        self.assertEqual(response._headers["content-type"], ("Content-Type", "text/plain"))
         self.assertEqual(response.content.decode("utf-8"), "OK")
 
     @mock.patch("app.enquiries.models.Enquiry.objects")

--- a/app/enquiries/tests/test_serializers.py
+++ b/app/enquiries/tests/test_serializers.py
@@ -1,6 +1,4 @@
-from django.test import Client, TestCase
-from django.urls import reverse
-from rest_framework import status
+from django.test import TestCase
 
 import app.enquiries.ref_data as ref_data
 from app.enquiries import serializers
@@ -24,39 +22,35 @@ class EnquiriesSerializersTestCase(TestCase):
         self.assertEqual(enquiry.created.strftime("%d %B %Y"), sr_data["created"])
         self.assertEqual(enquiry.modified.strftime("%d %B %Y"), sr_data["modified"])
         self.assertEqual(
-            enquiry.date_added_to_datahub.strftime("%d %B %Y"),
-            sr_data["date_added_to_datahub"],
+            enquiry.date_added_to_datahub.strftime("%d %B %Y"), sr_data["date_added_to_datahub"]
         )
         self.assertEqual(
-            enquiry.project_success_date.strftime("%d %B %Y"),
-            sr_data["project_success_date"],
+            enquiry.project_success_date.strftime("%d %B %Y"), sr_data["project_success_date"]
         )
         self.assertEqual(
             get_display_value(ref_data.EnquiryStage, enquiry.enquiry_stage),
-            sr_data["enquiry_stage"],
+            sr_data["enquiry_stage"]
+        )
+        self.assertEqual(
+            get_display_value(ref_data.InvestmentReadiness, enquiry.investment_readiness),
+            sr_data["investment_readiness"]
         )
         self.assertEqual(
             get_display_value(
-                ref_data.InvestmentReadiness, enquiry.investment_readiness
+                ref_data.InvestmentProgramme, enquiry.specific_investment_programme,
             ),
-            sr_data["investment_readiness"],
+            sr_data["specific_investment_programme"]
         )
         self.assertEqual(
-            get_display_value(
-                ref_data.InvestmentProgramme, enquiry.specific_investment_programme
-            ),
-            sr_data["specific_investment_programme"],
-        )
-        self.assertEqual(
-            get_display_value(ref_data.Country, enquiry.country), sr_data["country"],
+            get_display_value(ref_data.Country, enquiry.country), sr_data["country"]
         )
         self.assertEqual(
             get_display_value(ref_data.PrimarySector, enquiry.primary_sector),
-            sr_data["primary_sector"],
+            sr_data["primary_sector"]
         )
         self.assertEqual(
             get_display_value(ref_data.InvestmentType, enquiry.investment_type),
-            sr_data["investment_type"],
+            sr_data["investment_type"]
         )
 
     def test_enquirer_serializer(self):
@@ -69,6 +63,7 @@ class EnquiriesSerializersTestCase(TestCase):
         self.assertEqual(enquirer.first_name, sr_data["first_name"])
         self.assertEqual(enquirer.last_name, sr_data["last_name"])
         self.assertEqual(enquirer.email, sr_data["email"])
+
 
 class OwnerSerializerTestCase(TestCase):
     def test_owner_serializer(self):

--- a/app/enquiries/tests/test_utils.py
+++ b/app/enquiries/tests/test_utils.py
@@ -1,20 +1,11 @@
-import codecs
-import csv
-import io
-
-
 from django.test import Client, TestCase
 from faker import Faker
 
 import app.enquiries.tests.utils as test_utils
-from app.enquiries import models, ref_data, utils
+from app.enquiries import models, utils
 
-from app.enquiries.tests.factories import (
-    EnquiryFactory,
-    create_fake_enquiry_csv_row,
-    get_random_item,
-    get_display_name,
-)
+from app.enquiries.tests.factories import create_fake_enquiry_csv_row
+
 
 class EnquiryViewTestCase(TestCase):
     def setUp(self):
@@ -27,38 +18,35 @@ class EnquiryViewTestCase(TestCase):
         """
         csv_data = create_fake_enquiry_csv_row()
         expected_kwargs = {
-            key.replace('enquirer_', 'enquirer__'): value
-            for key, value in csv_data.items()
+            key.replace("enquirer_", "enquirer__"): value for key, value in csv_data.items()
         }
 
         qs_kwargs = utils.csv_row_to_enquiry_filter_kwargs(csv_data)
 
-        self.assertEqual(
-            len(expected_kwargs.keys()),
-            len(qs_kwargs.keys())
-            )
-        
+        self.assertEqual(len(expected_kwargs.keys()), len(qs_kwargs.keys()))
+
         for key in expected_kwargs:
             self.assertTrue(key in qs_kwargs)
             self.assertEqual(qs_kwargs[key], expected_kwargs[key])
 
     def test_util_row_to_enquiry(self):
         """
-        Tests that the utility functions create the enquiry record with the correct data
+        Tests that the utility functions create the enquiry record with
+        the correct data
         """
         csv_data = create_fake_enquiry_csv_row()
         utils.row_to_enquiry(csv_data)
         qs_args = utils.csv_row_to_enquiry_filter_kwargs(csv_data)
 
-        exists = models.Enquiry.objects.filter(
-            **qs_args
-        ).exists()
+        exists = models.Enquiry.objects.filter(**qs_args).exists()
         self.assertTrue(exists)
+
 
 class UtilsTestCase(test_utils.BaseEnquiryTestCase):
     def test_helper_logout(self):
         """
-        Tests that the `self.logged` property is correctly set when logging in/out
+        Tests that the `self.logged` property is correctly set when
+        logging in/out
         """
         self.login()
         self.assertEqual(self.logged_in, True)

--- a/app/enquiries/utils.py
+++ b/app/enquiries/utils.py
@@ -1,45 +1,36 @@
-import csv
-import io
-import typing
-
 from django.conf import settings
-
 from openpyxl import Workbook
 
-import app.enquiries.ref_data as ref_data
-from app.enquiries.models import Enquirer, Enquiry
+from app.enquiries import ref_data
+from app.enquiries.models import Enquirer, Enquiry, Owner
 
-
-from django.db.models import QuerySet
-
-from app.enquiries import models, serializers
-
-
-ENQUIRER_FIELDS = models.Enquirer._meta.get_fields()
-ENQUIRY_FIELDS = models.Enquiry._meta.get_fields()
-OWNER_FIELDS = models.Owner._meta.get_fields()
+ENQUIRER_FIELDS = Enquirer._meta.get_fields()
+ENQUIRY_FIELDS = Enquiry._meta.get_fields()
+OWNER_FIELDS = Owner._meta.get_fields()
 
 ENQUIRER_FIELD_NAMES = [f.name for f in ENQUIRER_FIELDS]
 ENQUIRY_FIELD_NAMES = [f.name for f in ENQUIRY_FIELDS]
 ENQUIRY_OWN_FIELD_NAMES = list(filter(lambda x: x != "enquirer", ENQUIRY_FIELD_NAMES))
 OWNER_FIELD_NAMES = [f.name for f in OWNER_FIELDS]
 
-EXPORT_FIELD_NAMES = ENQUIRY_OWN_FIELD_NAMES + [
-    "enquirer_" + n for n in ENQUIRER_FIELD_NAMES
-]
+EXPORT_FIELD_NAMES = ENQUIRY_OWN_FIELD_NAMES + ["enquirer_" + n for n in ENQUIRER_FIELD_NAMES]
 
 
 def get_oauth_payload(request):
     """
-    Returns the Staff SSO oauth data stored in the session (i.e. oauth token, expiry time etc )
-    (the oauth data is need for authentication with data and other services authenticated via Staff SSO)
+    Returns the Staff SSO oauth data stored in the session (i.e. oauth token,
+    expiry time etc)
+
+    The oauth data is needed for authentication with data and other services
+    authenticated via Staff SSO).
     """
     return request.session.get(settings.AUTHBROKER_TOKEN_SESSION_KEY, None)
 
 
 def row_to_enquiry(row: dict) -> Enquirer:
     """
-    Takes an dict representing a CSV row and create an Enquiry instance before saving it to the db
+    Takes an dict representing a CSV row and create an Enquiry instance before
+    saving it to the db
     """
     row_data = row.copy()
 
@@ -53,11 +44,12 @@ def row_to_enquiry(row: dict) -> Enquirer:
             # then skip it to assign the specified default in model
             if key == "enquirer_request_for_call" and value == "":
                 continue
-            enquirer_items[key.split('_', 1)[1]] = value
+            enquirer_items[key.split("_", 1)[1]] = value
 
-    enquirer = models.Enquirer(**enquirer_items)
+    enquirer = Enquirer(**enquirer_items)
 
-    # validate enquirer before saving - https://docs.djangoproject.com/en/3.0/ref/models/instances/#django.db.models.Model.full_clean
+    # validate enquirer before saving -
+    # https://docs.djangoproject.com/en/3.0/ref/models/instances/#django.db.models.Model.full_clean
     enquirer.full_clean()
 
     # this is an optional field, if the value is blank ensure it gets default choice
@@ -78,30 +70,30 @@ def row_to_enquiry(row: dict) -> Enquirer:
 
 def csv_row_to_enquiry_filter_kwargs(csv_row: dict) -> dict:
     """
-    Takes a dict (represents a CSV row as exported by the tool ) and returns a dict representing a model query
-    i.e. enquiry__enquirer__first_name to access -> enquiry.enquirer.first_name
+    Takes a dict (represents a CSV row as exported by the tool) and returns
+    a dict representing a model query i.e.:
+    enquiry__enquirer__first_name to access -> enquiry.enquirer.first_name.
     """
 
     # build queryset filter params
-    qs_kwargs = {
-        key.replace("enquirer_", "enquirer__"): value for key, value in csv_row.items()
-    }
+    qs_kwargs = {key.replace("enquirer_", "enquirer__"): value for key, value in csv_row.items()}
 
     return qs_kwargs
 
 
 def generate_import_template(file_obj):
     """
-    This function generates an .XLSX spreadsheet for use by by IST team to capture enquiries.
-    The main sheet 'enquiries' is the one end users use to capture information.
-    
+    This function generates an .XLSX spreadsheet for use by by IST team to
+    capture enquiries.
+
+    The main sheet 'enquiries' is used by end users to capture information.
+
     The enquiry sheet columns are listed in:
-    
+
         app.enquiries.ref_data.py:IMPORT_COL_NAMES
 
-    enquirer_first_name | enquirer_last_name | enquirer_job_title | enquirer_email | enquirer_phone | enquirer_request_for_call | country | company_name | primary_sector | company_hq_address | website | investment_readiness | enquiry_stage | enquiry_text | notes
-    
-    The additional sheets list valid options (i.e. Country names etc) which enable end users to implement their own form of validation.
+    The additional sheets list valid options (i.e. Country names etc) which
+    enable end users to implement their own form of validation.
 
     The fields for these sheets are also listed in ref_data.py
 
@@ -137,18 +129,17 @@ def generate_import_template(file_obj):
 def parse_error_messages(e):
     """
     Take an error and parse the messages in human-readable form.
-
     Returns a list of error messages
     Where there are message dictionaries, separates out each message,
     parsing the keys into sentence case with title capitalisations
     """
     response = []
 
-    if hasattr(e, 'message_dict'):
+    if hasattr(e, "message_dict"):
         for key, value in e.message_dict.items():
             msg = f'{key.replace("_", " ").title()}:'
             for v in value:
-                msg += f' {v}'
+                msg += f" {v}"
             response.append(msg)
     else:
         response.append(str(e))

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -139,9 +139,7 @@ def truncate_response_data(response_data, block_size=4):
     block_pivot = block_size // 2
     start_of_current_block = abs(current_page_num - block_pivot)
     start_of_last_block = last_page["page_number"] - block_size
-    block_start_index = min(
-        start_of_current_block, start_of_last_block, current_page_index,
-    )
+    block_start_index = min(start_of_current_block, start_of_last_block, current_page_index)
 
     truncated_pages = pages[block_start_index:][:block_size]
     first_of_truncated_pages_num = truncated_pages[0]["page_number"]

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,9 +1,8 @@
 def add_cache_control_header_middleware(get_response):
-
     def middleware(request):
 
         response = get_response(request)
-        response["Cache-Control"] = 'max-age=0, no-cache, no-store, must-revalidate, private'
+        response["Cache-Control"] = "max-age=0, no-cache, no-store, must-revalidate, private"
         return response
 
     return middleware

--- a/app/testfixtureapi/tests.py
+++ b/app/testfixtureapi/tests.py
@@ -16,33 +16,25 @@ from app.enquiries.tests.factories import (
     OwnerFactory,
 )
 
-RESET_URL = reverse('testfixtureapi:reset-fixtures')
+RESET_URL = reverse("testfixtureapi:reset-fixtures")
 SEED_USER_DATA = {
-    'username': 'seeduser',
-    'first_name': 'Seed',
-    'last_name': 'User',
-    'email': 'seed.user@example.com',
+    "username": "seeduser",
+    "first_name": "Seed",
+    "last_name": "User",
+    "email": "seed.user@example.com",
 }
 
 
 def test_url_not_found_if_not_setup(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = None
-    response = Client().post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
+    response = Client().post(RESET_URL, SEED_USER_DATA, content_type="application/json")
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.django_db
 def test_url_found_if_env_setup(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = True
-    response = Client().post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
+    response = Client().post(RESET_URL, SEED_USER_DATA, content_type="application/json")
     assert response.status_code == status.HTTP_201_CREATED
 
 
@@ -50,11 +42,7 @@ def test_url_found_if_env_setup(settings):
 def test_new_enquirer_removed_by_method(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = True
     new_enquirer_pk = EnquirerFactory().pk
-    Client().post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
+    Client().post(RESET_URL, SEED_USER_DATA, content_type="application/json")
     with pytest.raises(Enquirer.DoesNotExist):
         Enquirer.objects.get(pk=new_enquirer_pk)
 
@@ -63,11 +51,7 @@ def test_new_enquirer_removed_by_method(settings):
 def test_new_enquiry_removed_by_method(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = True
     new_enquiry_pk = EnquiryFactory().pk
-    Client().post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
+    Client().post(RESET_URL, SEED_USER_DATA, content_type="application/json")
     with pytest.raises(Enquiry.DoesNotExist):
         Enquiry.objects.get(pk=new_enquiry_pk)
 
@@ -76,11 +60,7 @@ def test_new_enquiry_removed_by_method(settings):
 def test_new_owner_removed_by_method(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = True
     new_owner_pk = OwnerFactory().pk
-    Client().post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
+    Client().post(RESET_URL, SEED_USER_DATA, content_type="application/json")
     with pytest.raises(Owner.DoesNotExist):
         Owner.objects.get(pk=new_owner_pk)
 
@@ -88,28 +68,20 @@ def test_new_owner_removed_by_method(settings):
 @pytest.mark.django_db
 def test_fixture_owner_created_by_method(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = True
-    owner_email = 'ist.user.1@example.com'
+    owner_email = "ist.user.1@example.com"
     with pytest.raises(Owner.DoesNotExist):
         Owner.objects.get(email=owner_email)
-    Client().post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
+    Client().post(RESET_URL, SEED_USER_DATA, content_type="application/json")
     assert Owner.objects.filter(email=owner_email).count() == 1
 
 
 @pytest.mark.django_db
 def test_fixture_enquirer_created_by_method(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = True
-    enquirer_email = 'evelyn.wang@example.com'
+    enquirer_email = "evelyn.wang@example.com"
     with pytest.raises(Enquirer.DoesNotExist):
         Enquirer.objects.get(email=enquirer_email)
-    Client().post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
+    Client().post(RESET_URL, SEED_USER_DATA, content_type="application/json")
     assert Enquirer.objects.filter(email=enquirer_email).count() == 1
 
 
@@ -119,27 +91,19 @@ def test_fixture_enquiry_created_by_method(settings):
     enquiry_pk = 1
     with pytest.raises(Enquiry.DoesNotExist):
         Enquiry.objects.get(pk=enquiry_pk)
-    Client().post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
+    Client().post(RESET_URL, SEED_USER_DATA, content_type="application/json")
     enquiry = Enquiry.objects.get(pk=enquiry_pk)
-    assert enquiry.company_name == 'ABC Electronics Co.'
+    assert enquiry.company_name == "ABC Electronics Co."
 
 
 @pytest.mark.django_db
 def test_seed_user_created_as_specified(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = True
-    Client().post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
-    created_user = Owner.objects.get(email=SEED_USER_DATA['email'])
-    assert created_user.username == SEED_USER_DATA['username']
-    assert created_user.first_name == SEED_USER_DATA['first_name']
-    assert created_user.last_name == SEED_USER_DATA['last_name']
+    Client().post(RESET_URL, SEED_USER_DATA, content_type="application/json")
+    created_user = Owner.objects.get(email=SEED_USER_DATA["email"])
+    assert created_user.username == SEED_USER_DATA["username"]
+    assert created_user.first_name == SEED_USER_DATA["first_name"]
+    assert created_user.last_name == SEED_USER_DATA["last_name"]
 
 
 @pytest.mark.django_db
@@ -147,11 +111,7 @@ def test_seed_user_is_logged_in(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = True
     client = Client()
     assert SESSION_KEY not in client.session
-    client.post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json'
-    )
+    client.post(RESET_URL, SEED_USER_DATA, content_type="application/json")
     assert SESSION_KEY in client.session
 
 
@@ -169,13 +129,7 @@ def test_reset_method_ignores_csrf_for_authenticated_user(settings):
     settings.ALLOW_TEST_FIXTURE_SETUP = True
     client = Client(enforce_csrf_checks=True)
     client.post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json',
+        RESET_URL, SEED_USER_DATA, content_type="application/json",
     )
-    response = client.post(
-        RESET_URL,
-        SEED_USER_DATA,
-        content_type='application/json',
-    )
+    response = client.post(RESET_URL, SEED_USER_DATA, content_type="application/json",)
     assert response.status_code == status.HTTP_201_CREATED

--- a/app/testfixtureapi/urls.py
+++ b/app/testfixtureapi/urls.py
@@ -3,11 +3,7 @@ from django.urls import path
 from app.testfixtureapi.views import TestFixtureResetView
 
 
-app_name = 'testfixtureapi'
+app_name = "testfixtureapi"
 urlpatterns = [
-    path(
-        'reset-fixtures/',
-        TestFixtureResetView.as_view(),
-        name='reset-fixtures',
-    ),
+    path("reset-fixtures/", TestFixtureResetView.as_view(), name="reset-fixtures",),
 ]

--- a/app/testfixtureapi/views.py
+++ b/app/testfixtureapi/views.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.auth import login
 from django.core.management import call_command
-from rest_framework import authentication, status
+from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -24,6 +24,7 @@ class CsrfExemptSessionAuthentication(SessionAuthentication):
     DRF will enforce CSRF (unless we stop it).
 
     """
+
     def enforce_csrf(self, request):
         return
 
@@ -51,34 +52,29 @@ class TestFixtureResetView(APIView):
     be automatically logged in (to simplify the e2e testing cycle).
 
     """
+
     authentication_classes = (CsrfExemptSessionAuthentication,)
 
     def post(self, request, *args, **kwargs):
         if not settings.ALLOW_TEST_FIXTURE_SETUP:
             return Response(status=status.HTTP_404_NOT_FOUND)
         seed_user_data = {
-            'username': request.data['username'],
-            'first_name': request.data['first_name'],
-            'last_name': request.data['last_name'],
-            'email': request.data['email'],
+            "username": request.data["username"],
+            "first_name": request.data["first_name"],
+            "last_name": request.data["last_name"],
+            "email": request.data["email"],
         }
         Enquiry.objects.all().delete()
         Enquirer.objects.all().delete()
         Owner.objects.all().delete()
         call_command(
-            'loaddata',
-            'app/enquiries/fixtures/test_users.json',
-            app_label='enquiries',
+            "loaddata", "app/enquiries/fixtures/test_users.json", app_label="enquiries",
         )
         call_command(
-            'loaddata',
-            'app/enquiries/fixtures/test_enquiries.json',
-            app_label='enquiries',
+            "loaddata", "app/enquiries/fixtures/test_enquiries.json", app_label="enquiries",
         )
         seed_user = Owner.objects.create(**seed_user_data)
         login(
-            request,
-            seed_user,
-            backend='django.contrib.auth.backends.ModelBackend',
+            request, seed_user, backend="django.contrib.auth.backends.ModelBackend",
         )
         return Response(status=status.HTTP_201_CREATED)

--- a/app/testfixtureapi_urls.py
+++ b/app/testfixtureapi_urls.py
@@ -2,19 +2,19 @@
 testfixtureapi_urls
 -------------------
 
-Setting `ROOT_URLCONF` to use this module instead of the default `urls.py` will have
-the effect of adding the "Test Fixture API" URL(s) into the Django URL router.
+Setting `ROOT_URLCONF` to use this module instead of the default `urls.py`
+will have the effect of adding the "Test Fixture API" URL(s) into the Django
+URL router.
 
-Obviously therefore this should never EVER be enabled in a live service environment
-(this includes dev, staging, etc and OF COURSE production).
+Obviously therefore this should never EVER be enabled in a live service
+environment (this includes dev, staging, etc and OF COURSE production).
 
-For information on how to set up and use this feature in testing, please see the
-"Allowing for Fixture Reset during e2e tests" section of `README.md`.
+For information on how to set up and use this feature in testing, please
+see the "Allowing for Fixture Reset during e2e tests" section of `README.md`.
 """
 from app.urls import urlpatterns
 
 from django.urls import include, path
-
 
 urlpatterns.append(
     path('testfixtureapi/', include('app.testfixtureapi.urls')),

--- a/app/testfixtureapi_urls.py
+++ b/app/testfixtureapi_urls.py
@@ -11,9 +11,9 @@ Obviously therefore this should never EVER be enabled in a live service environm
 For information on how to set up and use this feature in testing, please see the
 "Allowing for Fixture Reset during e2e tests" section of `README.md`.
 """
-from django.urls import path, include
-
 from app.urls import urlpatterns
+
+from django.urls import include, path
 
 
 urlpatterns.append(

--- a/app/urls.py
+++ b/app/urls.py
@@ -16,9 +16,7 @@ Including another URLconf
 from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
-from django.views.generic import TemplateView
 
-import app.enquiries.ref_data as ref_data
 from app.enquiries import views
 from app.enquiries import ping
 
@@ -29,37 +27,19 @@ urlpatterns = [
     path("enquiry/", views.EnquiryCreateView.as_view(), name="enquiry-create"),
     path("enquiries/", views.EnquiryListView.as_view(), name="enquiry-list"),
     path(
-        "enquiries/template/",
-        views.ImportTemplateDownloadView.as_view(),
-        name="import-template",
+        "enquiries/template/", views.ImportTemplateDownloadView.as_view(), name="import-template",
     ),
-    path(
-        "enquiries/import",
-        views.ImportEnquiriesView.as_view(),
-        name="import-enquiries",
-    ),
-    path(
-        "enquiries/<int:pk>/", views.EnquiryDetailView.as_view(), name="enquiry-detail"
-    ),
-    path(
-        "enquiries/<int:pk>/edit", views.EnquiryEditView.as_view(), name="enquiry-edit"
-    ),
+    path("enquiries/import", views.ImportEnquiriesView.as_view(), name="import-enquiries"),
+    path("enquiries/<int:pk>/", views.EnquiryDetailView.as_view(), name="enquiry-detail"),
+    path("enquiries/<int:pk>/edit", views.EnquiryEditView.as_view(), name="enquiry-edit"),
     path(
         "enquiries/<int:pk>/company-search",
         views.EnquiryCompanySearchView.as_view(),
         name="enquiry-company-search",
     ),
-    path(
-        "enquiries/<int:pk>/delete",
-        views.EnquiryDeleteView.as_view(),
-        name="enquiry-delete",
-    ),
+    path("enquiries/<int:pk>/delete", views.EnquiryDeleteView.as_view(), name="enquiry-delete"),
     path("healthcheck/ping", ping.ping, name="ping"),
-    path(
-        "dh-adviser-search",
-        views.DataHubAdviserSearch.as_view(),
-        name="dh-adviser-search",
-    ),
+    path("dh-adviser-search", views.DataHubAdviserSearch.as_view(), name="dh-adviser-search"),
 ]
 
 

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings.common')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.common")
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,7 @@ import sys
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings.common')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.common")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -17,5 +17,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ django-widget-tweaks==1.4.5
 django-model-choices==1.0.0
 Faker==4.0.0
 factory-boy==2.12.0
+flake8==3.8.3
 gunicorn==20.0.4
 idna==2.8
 ipdb==0.12.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude = */migrations/*,__pycache__,manage.py,app/settings/*,env/*,venv/
+max-line-length = 99


### PR DESCRIPTION
## Description of change

This pull request formats all relevant python files in the app using flake8. This includes removing lots of unused imports, unused variables and spacing errors.

I have also added a flake8 configuration file which adds the following rules:

- Sets the max line length to be 99 - in-line with what PEP8 allows and what we have in data hub API
- Excludes certain files e.g. migrations, settings, pycache which do not benefit from being formatted with flake8

This PR is the first of 3 to bring flake8 into the repository, the next two will:

- Set up a pre-commit hook to run flake8 against new code being committed
- Set up flake8 to run in the circle ci build

## Test instructions

Run flake8 on this branch (`docker exec -it enquiry-mgmt-tool_app_1 flake8`)
Check there are no formatting errors
