### PR TITLE
Run flake8 in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
             ALLOW_TEST_FIXTURE_SETUP: allow
             DJANGO_SETTINGS_MODULE: app.settings.e2etest
       - run:
+          name: Run Flake8
+          command: docker-compose run app python -m flake8
+      - run:
           name: Run unit tests
           command: docker-compose run app python -m pytest --cov --cov-report=xml -s --ds=app.settings.djangotest -vvv app
       - codecov/upload:

--- a/app/enquiries/common/datahub_utils.py
+++ b/app/enquiries/common/datahub_utils.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 from django.forms.models import model_to_dict
 from mohawk import Sender
 from requests.exceptions import RequestException
+from urllib.error import HTTPError
 
 import app.enquiries.ref_data as ref_data
 from app.enquiries.utils import get_oauth_payload

--- a/app/enquiries/common/datahub_utils.py
+++ b/app/enquiries/common/datahub_utils.py
@@ -508,9 +508,9 @@ def dh_investment_create(request, enquiry, metadata=None):
 
     try:
         result = dh_request(request, access_token, "POST", url, payload)
-        
+
         result.raise_for_status()
-        
+
         response["result"] = result.json()
     except HTTPError as e:
         response["errors"].append(

--- a/app/enquiries/templatetags/enquiries_extras.py
+++ b/app/enquiries/templatetags/enquiries_extras.py
@@ -57,9 +57,11 @@ def is_optional(instance, field_name):
     field = get_instance_field(instance, field_name)
     return field.blank and field_name not in dh_required_fields
 
+
 @register.filter
 def can_be_default(field_name):
     return field_name in can_be_default_fields
+
 
 @register.filter
 def get_dh_company_url(enquiry):


### PR DESCRIPTION
## Description of change

This PR adds a command to run flake8 as part of the circle CI build.

This will mean that if the code in a pull request is not formatted according to flake8 the build on that pull request will fail.

This work is in addition to two other pull requests introducing flake8 into the codebase. #146 #144 

## Test instructions

Once this PR is merged I will test it against a new pull request with formatting errors to check that it fails.