### PR TITLE
Replace primary sector with ist sector in template

### DIFF
--- a/app/enquiries/management/commands/export_enquiries.py
+++ b/app/enquiries/management/commands/export_enquiries.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
                         e.enquirer.request_for_call,
                         e.country,
                         e.company_name,
-                        e.primary_sector,
+                        e.ist_sector,
                         e.company_hq_address,
                         e.website,
                         e.investment_readiness,

--- a/app/enquiries/models.py
+++ b/app/enquiries/models.py
@@ -100,8 +100,8 @@ class Enquiry(TimeStampedModel):
     )
     ist_sector = models.CharField(
         max_length=MAX_LENGTH,
-        choices=ref_data.IstSector.choices,
-        default=ref_data.IstSector.DEFAULT,
+        choices=ref_data.ISTSector.choices,
+        default=ref_data.ISTSector.DEFAULT,
         verbose_name="IST sector",
     )
     company_hq_address = models.CharField(max_length=MAX_LENGTH, verbose_name="Company HQ address")

--- a/app/enquiries/ref_data.py
+++ b/app/enquiries/ref_data.py
@@ -463,7 +463,7 @@ IMPORT_COL_NAMES = [
     "enquirer_request_for_call",
     "country",
     "company_name",
-    "primary_sector",
+    "ist_sector",
     "company_hq_address",
     "website",
     "investment_readiness",

--- a/app/enquiries/ref_data.py
+++ b/app/enquiries/ref_data.py
@@ -96,7 +96,7 @@ class PrimarySector(models.TextChoices):
     WATER = "WATER", _("Water")
 
 
-class IstSector(models.TextChoices):
+class ISTSector(models.TextChoices):
     DEFAULT = "DEFAULT", _("----")
     ITECH = "ITECH", _("ITECH")
     LIFE = "LIFE", _("Life Science")
@@ -483,7 +483,7 @@ MAP_ENQUIRY_FIELD_TO_REF_DATA = {
     "primary_sector": PrimarySector,
     "country": Country,
     "first_response_channel": FirstResponseChannel,
-    "ist_sector": IstSector,
+    "ist_sector": ISTSector,
     "first_hpo_selection": HpoSelection,
     "region": Region,
     "second_hpo_selection": HpoSelection,

--- a/app/enquiries/tests/factories.py
+++ b/app/enquiries/tests/factories.py
@@ -68,7 +68,7 @@ class EnquiryFactory(factory.django.DjangoModelFactory):
     marketing_channel = get_random_item(ref_data.MarketingChannel)
     how_they_heard_dit = get_random_item(ref_data.HowDidTheyHear)
     primary_sector = get_random_item(ref_data.PrimarySector)
-    ist_sector = get_random_item(ref_data.IstSector)
+    ist_sector = get_random_item(ref_data.ISTSector)
     company_hq_address = factory.Faker("address")
     country = get_random_item(ref_data.Country)
     region = get_random_item(ref_data.Region)
@@ -106,7 +106,7 @@ def create_fake_enquiry_csv_row():
         "enquirer_request_for_call": get_random_item(ref_data.RequestForCall),
         "country": get_random_item(ref_data.Country),
         "company_name": fake.company(),
-        "ist_sector": get_random_item(ref_data.IstSector),
+        "ist_sector": get_random_item(ref_data.ISTSector),
         "company_hq_address": fake.address(),
         "website": fake.url(),
         "investment_readiness": get_random_item(ref_data.InvestmentReadiness),

--- a/app/enquiries/tests/factories.py
+++ b/app/enquiries/tests/factories.py
@@ -106,7 +106,7 @@ def create_fake_enquiry_csv_row():
         "enquirer_request_for_call": get_random_item(ref_data.RequestForCall),
         "country": get_random_item(ref_data.Country),
         "company_name": fake.company(),
-        "primary_sector": get_random_item(ref_data.PrimarySector),
+        "ist_sector": get_random_item(ref_data.IstSector),
         "company_hq_address": fake.address(),
         "website": fake.url(),
         "investment_readiness": get_random_item(ref_data.InvestmentReadiness),

--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -56,7 +56,7 @@ def canned_enquiry():
         "how_they_heard_dit": get_random_item(ref_data.HowDidTheyHear),
         "website": "https://www.example.com/",
         "primary_sector": get_random_item(ref_data.PrimarySector),
-        "ist_sector": get_random_item(ref_data.IstSector),
+        "ist_sector": get_random_item(ref_data.ISTSector),
         "company_hq_address": faker.address(),
         "country": get_random_item(ref_data.Country),
         "region": get_random_item(ref_data.Region),

--- a/app/enquiries/utils.py
+++ b/app/enquiries/utils.py
@@ -107,7 +107,7 @@ def generate_import_template(file_obj):
         ref_data.EnquiryStage,
         ref_data.HowDidTheyHear,
         ref_data.InvestmentReadiness,
-        ref_data.IstSector,
+        ref_data.ISTSector,
         ref_data.RequestForCall,
         ref_data.MarketingChannel,
     ]

--- a/app/enquiries/utils.py
+++ b/app/enquiries/utils.py
@@ -107,7 +107,7 @@ def generate_import_template(file_obj):
         ref_data.EnquiryStage,
         ref_data.HowDidTheyHear,
         ref_data.InvestmentReadiness,
-        ref_data.PrimarySector,
+        ref_data.IstSector,
         ref_data.RequestForCall,
         ref_data.MarketingChannel,
     ]


### PR DESCRIPTION
## Description of change

We have received feedback from the users that when they are uploading enquiries via a CSV, these enquiries would have an `IST Sector` not a `Primary sector`, as the primary sector is only relevant for submitting an enquiry to Data Hub.

This PR replaces `Primary sector` with `IST Sector` in the CSV template as well as in the factory to create a csv row and the management command for exporting a CSV of all enquiries. 

I have also corrected the reference data class `IstSector` to be `ISTSector` as IST are initials.

## Test instructions

When you download the import template, there should now be an `ist_sector` field instead of `primary_sector`