### PR TITLE
Add the SESSION_COOKIE_AGE setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ Or in app/settings/*
 In which case, it will redirect to Django admin page for login so a superuser
 needs to be created first.
 
+#### OAuth Access Token Refreshment
+
+_Access tokens_ issued by Staff SSO have expiration time of 10 hours to
+just about outlive a user's working time. In order to always have a valid
+_access token_ this app limits the user's session to 9 hours. When the session
+expires, the user will be automatically redirected to `/auth/login` which will
+refresh both the session and the _access token_ and allows the user to use the
+app uninterrupted for another period of 9 hours.
+
+The session expiration can be configured with the optional `SESSION_COOKIE_AGE`
+environmental variable which defaults to 9 hours.
+
 ### Running tests
 
 To run all unit tests:

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -307,3 +307,8 @@ ACTIVITY_STREAM_ENQUIRY_DATA_OBJ = env('ACTIVITY_STREAM_ENQUIRY_DATA_OBJ')
 CSRF_COOKIE_SECURE = env('CSRF_COOKIE_SECURE', default=True)
 CSRF_COOKIE_HTTPONLY = env('CSRF_COOKIE_HTTPONLY', default=True)
 SESSION_COOKIE_SECURE = env('SESSION_COOKIE_SECURE', default=True)
+# Setting the session expiration to less than the expiration of the SSO access
+# token (currently 10 hours) is the simplest way of keeping the token valid.
+# It forces the user to go through the /auth/login endpoint just before the
+# token expires which gets the user a fresh one.
+SESSION_COOKIE_AGE = env('SESSION_COOKIE_AGE', default=60 * 60 * 9)

--- a/sample_env
+++ b/sample_env
@@ -72,6 +72,7 @@ ACTIVITY_STREAM_INITIAL_LOAD_DATE=01-January-2020
 CSRF_COOKIE_SECURE=False
 CSRF_COOKIE_HTTPONLY=False
 SESSION_COOKIE_SECURE=False
+# SESSION_COOKIE_AGE=36000 # Optional, defaults to 32400 (9 hours)
 
 # Set HSTS headers, only needs to be True in Production
 SET_HSTS_HEADERS=False


### PR DESCRIPTION
## Description of change

This PR sets the [`SESSION_COOKIE_AGE`](https://docs.djangoproject.com/en/3.0/ref/settings/#session-cookie-age) Django setting to 9 hours and allows it to be overriden with an env var of the same name. This is a measure against the SSO access token expiration, i.e. the session expires sooner than the token (10 hours), which redirects the user to `/auth/login/` and refreshes both the access token and session.

## Test instructions

1. Set the `SESSION_COOKIE_AGE` in your `.env` file to a short time e.g. a minute (`SESSION_COOKIE_AGE=60`).
2. Visit the app from your browser
3. Clear all cookies
4. Refresh the page
5. Verify that there was a cookie `sessionid` created with _Expires/Max Age_ set to a time and date corresponding to the aforementioned setting
6. Wait till the expiration period is over
7. Click on one of the enquiries
8. You should be redirected to `/auth/login`, then to the SSO service and then back to the home page.

