### PR TITLE
Show select options as optional if needed on enquiry detail page

### DIFF
--- a/app/enquiries/templates/snippets/summary_list_key_value.html
+++ b/app/enquiries/templates/snippets/summary_list_key_value.html
@@ -1,7 +1,7 @@
 {% load enquiries_extras %}
 <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-        {{ instance|get_field_verbose_name:field }} {% if instance|is_optional:field %} (optional){% endif %}
+        {{ instance|get_field_verbose_name:field }} {% if instance|is_optional:field or field|can_be_default %} (optional){% endif %}
     </dt>
     <dd class="govuk-summary-list__value"  id="{{ field }}">{% if instance|get_field_value:field == None %}{{ "----" }}{% else %}{{ instance|get_field_value:field }}{% endif %}</dd>
 </div>


### PR DESCRIPTION
## Description of change
Followup to #145 . Currently `<select>` fields that can be set to the default are marked as *(optional)* in the edit view for enquiries, but not the detail view. This brings the detail view in line with the edit view.

### Before
<img width="787" alt="before" src="https://user-images.githubusercontent.com/23265724/89275606-64741d80-d63a-11ea-94ff-caa688d570fe.png">

### After
<img width="621" alt="after" src="https://user-images.githubusercontent.com/23265724/89275629-6c33c200-d63a-11ea-93ad-3a97d1d4ad9d.png">
 
## Test instructions
Select an enquiry from the main list - 'Investment readiness' should be labelled as (optional). Generally, the fields marked as (optional) should match in the detail and edit views. 

