### PR TITLE
Update owner filter

### DIFF
--- a/app/enquiries/templates/partials/enquiry_filters.html
+++ b/app/enquiries/templates/partials/enquiry_filters.html
@@ -8,7 +8,7 @@
       </label>
 
       <select class="govuk-select" id="owner__id" name="owner__id">
-        <option disabled selected value></option>
+        <option selected>---</option>
         <option value="UNASSIGNED" {% query_params_value_selected 'UNASSIGNED' 'owner__id' query_params ' selected'  %}>
           Unassigned
         </option>

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -99,7 +99,7 @@ class PaginationWithPaginationMeta(PageNumberPagination):
             "current_page": self.page.number,
             "results": data,
             "filter_enquiry_stage": get_enquiry_field("enquiry_stage"),
-            "owners": models.Owner.objects.all().order_by("last_name"),
+            "owners": models.Owner.objects.all().order_by("first_name"),
             "query_params": self.request.GET,
             "total_pages": len(self.page.paginator.page_range),
             "pages": [

--- a/cypress/e2e_tests/specs/filter.test.js
+++ b/cypress/e2e_tests/specs/filter.test.js
@@ -106,8 +106,7 @@ const assertPage = (itemsPerPage, assert = () => {}) =>
 const testResults = (assert, expectedTotal, testPages) => {
   context('Results', () => {
     it(`Should show ${expectedTotal} total results`, () =>
-      cy.get('header')
-        .contains(`${expectedTotal} enquiries`)
+      cy.get('.big-number-of-enquiries').should('have.text', `${expectedTotal}`)
     )
 
     if (!testPages) {

--- a/cypress/e2e_tests/specs/filter.test.js
+++ b/cypress/e2e_tests/specs/filter.test.js
@@ -85,9 +85,16 @@ const setOwner = id =>
   cy.get('label').contains('Owner').next()
     .select(id === UNASSIGNED ? 'Unassigned' : USERS[id])
 
+const clearOwner = () => {
+  cy
+    .get('label').contains('Owner')
+    .next()
+    .select('---')
+}
+
 const assertOwnerSet = id =>
   cy.get('label').contains('Owner').next()
-    .should('have.value', id ? id : null)
+    .should('have.value', id ? id : '---')
 
 const assertPage = (itemsPerPage, assert = () => {}) =>
   cy.get('article')
@@ -706,4 +713,13 @@ describe('Filters', () => {
     },
     expectedTotal: 0,
   })
+  
+  it("Should display results for all owners when the '---' option is selected", () => {
+    setOwner(1),
+    submitFilters()
+    clearOwner()
+    submitFilters()
+    cy.get('.big-number-of-enquiries').should('have.text', '47')
+  })
+
 })


### PR DESCRIPTION
## Description of change

This PR updates the owner filter on the enquiries list page by:

1. Ordering the dropdown options by first name instead of last name to align with common practice across DIT services and improve readability.
2. Adding a default '---' option to the Owner dropdown, so that a user can clear the owner filter without clearing all filters.

As the test for the default option is much simpler than the other filter tests, I have opted to create a new one rather than use `testFilters`.

## Test instructions

1. Go to the owner filter
2. Check that the owners are ordered alphabetically by first name
3. Choose an owner to filter by and apply
4. Choose the default '---' option and check that it shows results for all owners 