### PR TITLE
Handle user submitting enquiry upload without a file selected

### DIFF
--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -494,9 +494,15 @@ class ImportEnquiriesView(TemplateView):
         enquiries_key = "enquiries"
 
         file_obj = request.FILES.get(enquiries_key)
+        if not file_obj:
+            messages.error(
+                self.request,
+                "No file was selected. Please choose a file to upload.",
+            )
+            return HttpResponseRedirect(reverse("import-enquiries"))
+
         if not (
-            file_obj
-            and file_obj.name.endswith(".csv")
+            file_obj.name.endswith(".csv")
             and file_obj.content_type in settings.IMPORT_ENQUIRIES_MIME_TYPES
         ):
             messages.error(


### PR DESCRIPTION
## Description of change
Currently, if the user attempts to submit the 'Import Enquiries' form without selecting a file, there is a 500 error. This adds a clear error message instead.

## Test instructions
- Visit http://localhost:8000/enquiries/import . 
- Click 'Upload File' without selecting a file to add.
- You should see the following: 
<img width="1018" alt="Screenshot 2020-08-04 at 16 00 38" src="https://user-images.githubusercontent.com/23265724/89310038-1b3cc180-d66c-11ea-9995-1f81f73e1329.png">
