### PR TITLE
Handle user submitting 'Import Enquiries' form without selecting a file.

### DIFF
--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -439,9 +439,32 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
             # clear entries for next mime type run
             Enquiry.objects.all().delete()
 
+    def test_enquiry_import_post_blank(self):
+        """
+        Test an unsuccessful import, where no file is provided
+        """
+        initial_count = Enquiry.objects.count()
+
+        response = self.client.post(
+            reverse("import-enquiries"), {"enquiries": ""}, follow=True
+        )
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        error_message = soup.select(".error")[0].text
+
+        self.assertEqual(error_message, "No file was selected. Choose a file to upload.")
+
+        # test atomic transactions
+        final_count = Enquiry.objects.count()
+        self.assertEqual(
+            final_count,
+            initial_count,
+            f"atomic transaction should prevent any records being created. Found: {final_count}",
+        )
+
     def test_enquiry_import_post_error(self):
         """
-        Test a unsuccessful import
+        Test an unsuccessful import
         Creates an enquiry dict, updates few fields and ensures
         the data is updated after submitting the form
         """

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -494,9 +494,15 @@ class ImportEnquiriesView(TemplateView):
         enquiries_key = "enquiries"
 
         file_obj = request.FILES.get(enquiries_key)
+        if not file_obj:
+            messages.error(
+                self.request,
+                "No file was selected. Choose a file to upload.",
+            )
+            return HttpResponseRedirect(reverse("import-enquiries"))
+
         if not (
-            file_obj
-            and file_obj.name.endswith(".csv")
+            file_obj.name.endswith(".csv")
             and file_obj.content_type in settings.IMPORT_ENQUIRIES_MIME_TYPES
         ):
             messages.error(


### PR DESCRIPTION
## Description of change
Currently, if the user attempts to submit the 'Import Enquiries' form without selecting a file, there is a 500 error. This adds a clear error message instead.

## Test instructions
Visit http://localhost:8000/enquiries/import .
Click 'Upload File' without selecting a file to add.
You should see the following:
<img width="1018" alt="Screenshot 2020-08-04 at 16 00 38" src="https://user-images.githubusercontent.com/23265724/89315254-8b4e4600-d672-11ea-810c-c02318311a4c.png">
