### PR TITLE
Disable 'Date Added to DataHub' on enquiry edit form

### DIFF
--- a/app/enquiries/templates/enquiry_detail.html
+++ b/app/enquiries/templates/enquiry_detail.html
@@ -160,7 +160,12 @@
                 {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="investor_involvement_level" %}
                 {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="specific_investment_programme" %}
                 {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="client_relationship_manager" %}
-                {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="date_added_to_datahub" %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Date added to Data Hub
+                    </dt>
+                    <dd class="govuk-summary-list__value"  id="{{ date_added_to_datahub }}">{{ enquiry|get_dh_date_added }}</dd>
+                </div>
                 {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="project_code" %}
                 {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="datahub_project_status" %}
                 {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="project_success_date" %}

--- a/app/enquiries/templates/enquiry_edit.html
+++ b/app/enquiries/templates/enquiry_edit.html
@@ -135,7 +135,7 @@
 
                 <h3 class="govuk-heading-m">Enquiry details</h3>
 
-                <div class="enquiry-text">
+                <div class="read-only">
                     <div class="govuk-label">Enquiry text</div>
                     <p>{{ enquiry.enquiry_text }}</p>
                 </div>
@@ -252,8 +252,10 @@
                     {{ form.client_relationship_manager }}
                 </div>
 
-                <!-- TODO: Change label to 'Date added to Data Hub' -->
-                {% include 'snippets/enquiry_field_input_date.html' with instance=enquiry field="date_added_to_datahub" %}
+                <div class="read-only">
+                    <div class="govuk-label">Date added to Data Hub</div>
+                    <p>{{ enquiry|get_dh_date_added }}</p>
+                </div>
 
                 {% include 'snippets/enquiry_field_input.html' with instance=enquiry field="project_code" %}
 

--- a/cypress/e2e_tests/specs/edit.test.js
+++ b/cypress/e2e_tests/specs/edit.test.js
@@ -405,9 +405,9 @@ describe('Edit', () => {
               value: 'Data Hub user 1',
             },
             {
-              type: 'date',
+              type: NOT_EDITABLE,
               label: 'Date added to Data Hub',
-              value: '2020-02-03',
+              value: '03 February 2020',
             },
             {
               type: 'text',
@@ -630,11 +630,6 @@ describe('Edit', () => {
           value: 'Data Hub user 2',
         },
         {
-          type: 'date',
-          name: 'date_added_to_datahub',
-          value: '2020-08-10',
-        },
-        {
           type: 'text',
           name: 'project_code',
           value: '67542',
@@ -779,7 +774,7 @@ describe('Edit', () => {
               dd: 'Business Partnership (Non-FDI)',
             },
             { dt: 'Client Relationship Manager', dd: 'Data Hub user 2' },
-            { dt: 'Date added to Data Hub', dd: '10 August 2020' },
+            { dt: 'Date added to Data Hub', dd: 'Date not recorded'},
             { dt: 'Project code', dd: '67542' },
             { dt: 'Data Hub project status', dd: 'Verify Win' },
             { dt: 'Project success date', dd: '01 February 2026' },

--- a/sass/_enquiry_edit.scss
+++ b/sass/_enquiry_edit.scss
@@ -1,5 +1,5 @@
 $govuk-assets-path: '/static/assets/';
 
-.enquiry-text {
+.read-only {
     @include govuk-responsive-margin(6, "bottom");
 }


### PR DESCRIPTION
## Description of change
Updates the Enquiry edit form so that the 'Date Added to Data Hub' field is information-only. 

## Test instructions
Select an enquiry, select 'edit', and see:
<img width="538" alt="Screenshot 2020-08-05 at 11 19 16" src="https://user-images.githubusercontent.com/23265724/89401781-bcc81f80-d70d-11ea-930a-336b51d2aeac.png">
