### PR TITLE
Fix 'Edit' button for IE

### DIFF
--- a/app/enquiries/templates/enquiry_detail.html
+++ b/app/enquiries/templates/enquiry_detail.html
@@ -11,10 +11,10 @@
             <a href="{% url 'enquiry-list' %}" class="govuk-back-link">Back</a>
         </div>
         <div class="top-controls__edit-button-container">
-            <button onclick="window.location.href = `{% url 'enquiry-edit' enquiry.id %}`" class="govuk-button
+            <a href="{% url 'enquiry-edit' enquiry.id %}" class="govuk-button
             govuk-button--secondary govuk-!-margin-right-1 enquiry-edit__button" data-module="govuk-button">
                 Edit details
-            </button>
+            </a>
         </div>
     </div>
 

--- a/cypress/e2e_tests/selectors/details.js
+++ b/cypress/e2e_tests/selectors/details.js
@@ -1,4 +1,4 @@
 module.exports = {
   topControls: '.top-controls',
-  editDetailsButton: '.top-controls button',
+  editDetailsButton: '.top-controls .govuk-button',
 }

--- a/cypress/e2e_tests/specs/edit.test.js
+++ b/cypress/e2e_tests/specs/edit.test.js
@@ -26,7 +26,7 @@ describe('Edit', () => {
         .should('have.text', 'Back')
         .and('have.attr', 'href', '/enquiries/')
         .parents()
-        .find('button')
+        .find('a')
         .should('contain', 'Edit details')
 
       assertSummaryDetails([


### PR DESCRIPTION
## Description of change
Fixes 'Edit' button for IE users.

IE users were not able to access the 'edit' view from the 'edit' button. This was because there were backticks in the window location code, which IE doesn't recognise. 

## Test instructions

Visit the site (localhost) on Browserstack for IE 11. Select an Enquiry, then click 'Edit'. You should be directed to the Edit view.