### PR TITLE
Filter out emails sent to user before ingestion from Activity Stream

### DIFF
--- a/app/enquiries/common/as_utils.py
+++ b/app/enquiries/common/as_utils.py
@@ -187,6 +187,12 @@ def get_new_investment_enquiries(last_cursor=None, max_size=100):
     ACTIVITY_STREAM_INITIAL_LOAD_DATE determines the initial date
     from which the data is queried.
 
+    Two emails are sent for every enquiry, one to the user who filled
+    out the form and one to enquiries@invest-trade.uk for triage. Both of
+    these are present in activity stream. To avoid duplicate enquiries, the
+    emails sent to the user are ignored by filtering out emails which
+    were sent by noreply@invest.great.gov.uk.
+
     last_cursor indicates the last enquiry fetched (index and id).
     This is used to fetch next set of results when this is invoked again.
     """
@@ -212,6 +218,13 @@ def get_new_investment_enquiries(last_cursor=None, max_size=100):
                         "term": {
                             settings.ACTIVITY_STREAM_ENQUIRY_SEARCH_KEY2:
                                 settings.ACTIVITY_STREAM_ENQUIRY_SEARCH_VALUE2
+                        }
+                    },
+                    {
+                        "bool": {
+                            "must_not": {
+                                "term": {"actor.dit:emailAddress": "noreply@invest.great.gov.uk"}
+                            }
                         }
                     },
                 ]


### PR DESCRIPTION
## Description of change

This change fixes the current bug in the system which shows two entries for every enquiry.

Enquiries are ingested from Activity Stream in email form, via the Forms API. When a user fills out the enquiry form, two emails with details of the enquiry are sent: one to the user and one to the `enquiries@invest-trade.uk` mailbox. Both of these are ingested by Activity Stream.

As we want to add the emails sent to `enquiries@invest-trade.uk` to our system as enquiries, I have filtered out the emails sent to the user by ignoring emails sent by the `noreply@invest.great.gov.uk` address.

## Test instructions

You can test whether adding this query parameter works by using Kibana to query activity stream. 
Go to the link below and add the new query parameter from this PR to the list of filters.
https://activity-stream-elasticsearch.london.cloudapps.digital/app/kibana#/dev_tools/console?_g=()
(If the query doesn't persist in the link, message me and I will send you the query.

If you remove the final query, the number of hits should double.