### PR TITLE
Update celery tasks to use beat schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,8 +114,11 @@ app/**/static
 # app specific env files
 app/.env
 app/settings/.env
-celerybeat-schedule
 
 # cypress
 cypress/screenshots
 cypress/videos
+
+# celery
+celerybeat.pid
+celerybeat-schedule

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: ./web.sh
-celery: celery worker -A app -l info -Q celery -B
+celery: celery worker -A app -l info
+celerybeat: celery beat -A app -l info

--- a/app/enquiries/celery.py
+++ b/app/enquiries/celery.py
@@ -1,5 +1,8 @@
 import os
 from celery import Celery
+from celery.schedules import crontab
+
+from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.common")
@@ -9,3 +12,17 @@ app = Celery("app")
 # pickle the object when using Windows.
 app.config_from_object("django.conf:settings")
 app.autodiscover_tasks()
+
+DH_METADATA_FETCH_INTERVAL_HOURS = settings.DATA_HUB_METADATA_FETCH_INTERVAL_HOURS
+AS_ENQUIRIES_POLL_INTERVAL_MINS = settings.ACTIVITY_STREAM_ENQUIRY_POLL_INTERVAL_MINS
+
+app.conf.beat_schedule = {
+    "refresh-datahub-metadata": {
+        "task": "refresh_datahub_metadata",
+        "schedule": crontab(minute="0", hour=f"*/{DH_METADATA_FETCH_INTERVAL_HOURS}"),
+    },
+    "fetch-new-enquiries": {
+        "task": "fetch_new_enquiries",
+        "schedule": crontab(minute=f"*/{AS_ENQUIRIES_POLL_INTERVAL_MINS}"),
+    },
+}

--- a/app/enquiries/tasks.py
+++ b/app/enquiries/tasks.py
@@ -1,36 +1,27 @@
 import logging
 
-from celery.task.schedules import crontab
-from celery.decorators import periodic_task
 from datetime import datetime
 from django.conf import settings
 
+from app.enquiries.celery import app
 from app.enquiries.common.datahub_utils import dh_fetch_metadata
 from app.enquiries.common.as_utils import fetch_and_process_enquiries
 
 FETCH_INTERVAL_HOURS = f"*/{settings.DATA_HUB_METADATA_FETCH_INTERVAL_HOURS}"
 
 
-@periodic_task(
-    run_every=(crontab(hour=FETCH_INTERVAL_HOURS, minute="0")),
-    name="refresh_datahub_metadata",
-    ignore_result=True,
-)
+@app.task(name="refresh_datahub_metadata")
 def refresh_datahub_metadata():
     """ Periodically refreshes metadata in cache """
 
-    # set expiry few minutes before next refresh so that we
-    # ensure refresh fetch data again
+    # set expiry a few minutes before next refresh so that we
+    # ensure refresh fetches data again
     expiry_secs = settings.DATA_HUB_METADATA_FETCH_INTERVAL_HOURS * 60 * 60 - (5 * 60)
     dh_fetch_metadata(expiry_secs=expiry_secs)
     logging.info(f"Data Hub metadata last refreshed at {datetime.now()}")
 
 
-@periodic_task(
-    run_every=(crontab(minute=f"*/{settings.ACTIVITY_STREAM_ENQUIRY_POLL_INTERVAL_MINS}")),
-    name="fetch_new_enquiries",
-    ignore_result=True,
-)
+@app.task(name="fetch_new_enquiries")
 def fetch_new_enquiries():
     """ Periodically fetches new investment enquiries from AS """
 


### PR DESCRIPTION
## Description of change

This PR updates the two scheduled celery tasks in the app to use celery's beat schedule, rather than the deprecated decorator `@periodic_task`. 

The two tasks are linked to the celery app in `tasks.py` and then registered with `beat_schedule` in `celery.py`.

I have also added a command to start the beat scheduler to the `procfile` in addition to the celery worker. I have added this in place of using `-B` in the celery worker command, as it is recommended in the celery docs that this not be used in production, [see docs here](https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html#starting-the-scheduler).

## Test instructions

- In `celery.py` change the schedule of both tasks to `crontab(minute="*/1")`
- Run `docker-compose up` and open an interactive shell in the app container (`docker exec -it enquiry-mgmt-tool_app_1 bash`)
- Run the the beat scheduler using the command from the procfile
- In a separate terminal window, open another interactive shell and run the celery worker command from the procfile
- You should see both tasks being sent by the scheduler and received by the worker (you will get an error for the 'fetch_new_enquiries' task as it doesn't work locally)