### PR TITLE
Export enquiries as an .xlsx file instead of .csv

### DIFF
--- a/app/enquiries/templates/enquiry_list.html
+++ b/app/enquiries/templates/enquiry_list.html
@@ -36,7 +36,7 @@
                             </div>
                             <div class="download-button-container">
                                 <button
-                                    onclick="location.search += (location.search ? '&' : '') + 'format=csv' "
+                                    onclick="location.search += (location.search ? '&' : '') + 'format=xlsx' "
                                     class="govuk-button download-enquiries-button"
                                 >
                                     Download all

--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -562,12 +562,12 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
     def test_enquiry_list_csv_format(self):
         """
         Asserts that the view instance has no paginator if there's a
-        `format=csv` query string parameter
+        `format=xlsx` query string parameter
         """
         user = Owner.objects.get(username='test')
 
         request = RequestFactory().get(reverse("enquiry-list"),
-                                       dict(format='csv'))
+                                       dict(format='xlsx'))
         request.user = user
         response = EnquiryListView.as_view()(request)
         assert response.renderer_context['view'].paginator is None

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -19,6 +19,8 @@ from django.views.generic import DeleteView
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import UpdateView
 from django_filters import rest_framework as filters
+from drf_renderer_xlsx.mixins import XLSXFileMixin
+from drf_renderer_xlsx.renderers import XLSXRenderer
 from rest_framework import status
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
@@ -26,7 +28,6 @@ from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework.utils.urls import replace_query_param
 from rest_framework.views import APIView
-from rest_framework_csv.renderers import CSVRenderer
 
 from app.enquiries.common.datahub_utils import dh_investment_create
 from app.enquiries import forms, models, serializers, utils
@@ -251,7 +252,7 @@ class EnquiryFilter(filters.FilterSet):
         }
 
 
-class EnquiryListView(LoginRequiredMixin, ListAPIView):
+class EnquiryListView(XLSXFileMixin, LoginRequiredMixin, ListAPIView):
     """
     List all enquiries.
 
@@ -264,17 +265,18 @@ class EnquiryListView(LoginRequiredMixin, ListAPIView):
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = EnquiryFilter
     template_name = "enquiry_list.html"
-    renderer_classes = (TemplateHTMLRenderer, CSVRenderer)
+    renderer_classes = (TemplateHTMLRenderer, XLSXRenderer)
     serializer_class = serializers.EnquiryDetailSerializer
     pagination_class = PaginationWithPaginationMeta
+    filename = "rtt_enquiries_export.xlsx"
 
     def get_queryset(self):
         return models.Enquiry.objects.all()
 
     @property
     def paginator(self):
-        """This method override is here to disable pagination for the csv format"""
-        if self.request.query_params.get("format") == "csv":
+        """This method override is here to disable pagination for the xlsx format"""
+        if self.request.query_params.get("format") == "xlsx":
             self._paginator = None
         return super().paginator
 

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -233,9 +233,6 @@ IMPORT_ENQUIRIES_MIME_TYPES = ["text/csv", "application/vnd.ms-excel"]
 IMPORT_TEMPLATE_FILENAME = 'rtt_enquiries_import_template.xlsx'
 IMPORT_TEMPLATE_MIMETYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 UPLOAD_CHUNK_SIZE = 256000
-EXPORT_OUTPUT_FILE_SLUG = 'rtt_enquiries_export'
-EXPORT_OUTPUT_FILE_EXT = 'csv'
-EXPORT_OUTPUT_FILE_MIMETYPE = 'text/csv'
 
 # Data Hub settings
 DATA_HUB_METADATA_URL = env('DATA_HUB_METADATA_URL')

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ django-redis==4.11.0
 django-rest-knox==4.1.0
 django-staff-sso-client==2.2.0
 djangorestframework==3.10.3
-djangorestframework-csv==2.1.0
+drf-renderer-xlsx==0.3.7
 drf-writable-nested==0.5.3
 django-widget-tweaks==1.4.5
 django-model-choices==1.0.0


### PR DESCRIPTION
## Description of change

Due to the fact that users are unable to open CSV files, this PR replaces the CSV renderer used in the `EnquiryListView` with an XLSX renderer.

I have also removed some unused settings from `common.py` related to the export file.

## Test instructions

Click 'Download all' on the homepage and the file should have an `xlsx` extension.