### PR TITLE
Add admin models

### DIFF
--- a/app/enquiries/admin.py
+++ b/app/enquiries/admin.py
@@ -1,1 +1,33 @@
-# Register your models here.
+from django.contrib import admin
+
+from app.enquiries.models import Enquiry, Enquirer, Owner
+
+
+def all_fields_of(model, exclude=()):
+    return [field.name for field in
+            model._meta.fields if field.name not in exclude]
+
+
+@admin.register(Enquirer)
+class EnquirerAdmin(admin.ModelAdmin):
+    list_display = all_fields_of(Enquirer)
+
+
+@admin.register(Owner)
+class OwnerAdmin(admin.ModelAdmin):
+    list_display = all_fields_of(Owner, ("password",))
+
+
+def enquirer(obj):
+    return f"{obj.enquirer.first_name} {obj.enquirer.last_name}"
+
+
+enquirer.short_description = "Enquirer"
+
+
+@admin.register(Enquiry)
+class EnquiryAdmin(admin.ModelAdmin):
+    list_display = ("owner", enquirer, "region", "country", "enquiry_stage",
+                    "datahub_project_status", "date_received",
+                    "date_added_to_datahub", "primary_sector", "project_code",
+                    "project_name")

--- a/app/enquiries/models.py
+++ b/app/enquiries/models.py
@@ -252,6 +252,7 @@ class Enquiry(TimeStampedModel):
 
     class Meta:
         ordering = ["-created"]
+        verbose_name_plural = "Enquiries"
 
 
 class ReceivedEnquiryCursor(models.Model):


### PR DESCRIPTION
## Description of change

Enables editing the `Enquiry`, `Owner` and `Enquirer` models in Django admin.

## Test instructions

1. Go to `/admin/`
2. You should see the three sections there

<img width="631" alt="Screen Shot 2020-08-05 at 5 04 39 PM" src="https://user-images.githubusercontent.com/2333157/90123597-fffe4000-dd56-11ea-82c4-2202e8ee9d2f.png">
<img width="1178" alt="Screen Shot 2020-08-05 at 5 04 57 PM" src="https://user-images.githubusercontent.com/2333157/90123633-0e4c5c00-dd57-11ea-86d7-5fe587806701.png">
<img width="1183" alt="Screen Shot 2020-08-05 at 5 05 09 PM" src="https://user-images.githubusercontent.com/2333157/90123634-0ee4f280-dd57-11ea-93be-83d7c03e1165.png">
<img width="1182" alt="Screen Shot 2020-08-05 at 5 05 25 PM" src="https://user-images.githubusercontent.com/2333157/90123638-0f7d8900-dd57-11ea-88ee-e4258a1f1bc4.png">
