### PR TITLE
Autopopulate date_received field when not provided

### DIFF
--- a/app/enquiries/common/as_utils.py
+++ b/app/enquiries/common/as_utils.py
@@ -279,6 +279,7 @@ def fetch_and_process_enquiries():
             enquirer_instance = Enquirer.objects.create(**enquirer)
             enquiry_obj = Enquiry.objects.create(**enquiry, enquirer=enquirer_instance)
             enquiry_obj.created = published
+            enquiry_obj.date_received = published
             enquiry_obj.save()
             logging.info(
                 f"""

--- a/app/enquiries/tests/factories.py
+++ b/app/enquiries/tests/factories.py
@@ -115,3 +115,9 @@ def create_fake_enquiry_csv_row():
         "notes": fake.sentence(nb_words=20),
         "date_received": fake.date(),
     }
+
+
+def create_fake_enquiry_csv_row_no_date_received():
+    csv_row_dict = create_fake_enquiry_csv_row()
+    csv_row_dict.pop("date_received")
+    return csv_row_dict

--- a/app/enquiries/tests/test_as_integration.py
+++ b/app/enquiries/tests/test_as_integration.py
@@ -159,6 +159,9 @@ class ActivityStreamIntegrationTests(TestCase):
         """
         Test that fetches sample enquiries data, parses them and creates
         Enquiry objects and asserts data matches with input data
+
+        Checks that for enquiries which come through activity stream the
+        date_received field is populated with the date of creation.
         """
         with requests_mock.Mocker() as m:
             url = settings.ACTIVITY_STREAM_SEARCH_URL
@@ -168,6 +171,8 @@ class ActivityStreamIntegrationTests(TestCase):
             self.assertEqual(Enquiry.objects.count(), 0)
             fetch_and_process_enquiries()
             self.assertEqual(Enquiry.objects.count(), 2)
+            enquiry = Enquiry.objects.all().first()
+            assert enquiry.date_received == enquiry.created
 
             for detail in details:
                 if not detail["skip"]:

--- a/app/enquiries/tests/test_as_integration.py
+++ b/app/enquiries/tests/test_as_integration.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.forms.models import model_to_dict
 from django.test import TestCase
 from faker import Faker
+from freezegun import freeze_time
 
 from app.enquiries.models import Enquiry, Enquirer
 from app.enquiries.common.as_utils import fetch_and_process_enquiries
@@ -155,6 +156,7 @@ def get_enquiries_data():
 
 
 class ActivityStreamIntegrationTests(TestCase):
+    @freeze_time()
     def test_fetch_new_enquiries(self):
         """
         Test that fetches sample enquiries data, parses them and creates

--- a/app/enquiries/tests/test_utils.py
+++ b/app/enquiries/tests/test_utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from django.test import Client, TestCase
 from faker import Faker
+from freezegun import freeze_time
 
 import app.enquiries.tests.utils as test_utils
 from app.enquiries import models, utils
@@ -45,6 +46,7 @@ class EnquiryViewTestCase(TestCase):
         exists = models.Enquiry.objects.filter(**qs_args).exists()
         self.assertTrue(exists)
 
+    @freeze_time()
     def test_util_row_to_enquiry_no_date_received(self):
         """
         Tests that when an enquiry is uploaded without date_received

--- a/app/enquiries/tests/test_utils.py
+++ b/app/enquiries/tests/test_utils.py
@@ -1,10 +1,14 @@
+from datetime import datetime
 from django.test import Client, TestCase
 from faker import Faker
 
 import app.enquiries.tests.utils as test_utils
 from app.enquiries import models, utils
 
-from app.enquiries.tests.factories import create_fake_enquiry_csv_row
+from app.enquiries.tests.factories import (
+    create_fake_enquiry_csv_row,
+    create_fake_enquiry_csv_row_no_date_received
+)
 
 
 class EnquiryViewTestCase(TestCase):
@@ -40,6 +44,15 @@ class EnquiryViewTestCase(TestCase):
 
         exists = models.Enquiry.objects.filter(**qs_args).exists()
         self.assertTrue(exists)
+
+    def test_util_row_to_enquiry_no_date_received(self):
+        """
+        Tests that when an enquiry is uploaded without date_received
+        populated, the field is populated with the current date.
+        """
+        csv_data = create_fake_enquiry_csv_row_no_date_received()
+        enquiry = utils.row_to_enquiry(csv_data)
+        assert enquiry.date_received.date() == datetime.now().date()
 
 
 class UtilsTestCase(test_utils.BaseEnquiryTestCase):

--- a/app/enquiries/utils.py
+++ b/app/enquiries/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from django.conf import settings
 from openpyxl import Workbook
 
@@ -29,7 +30,7 @@ def get_oauth_payload(request):
 
 def row_to_enquiry(row: dict) -> Enquirer:
     """
-    Takes an dict representing a CSV row and create an Enquiry instance before
+    Takes a dict representing a CSV row and create an Enquiry instance before
     saving it to the db
     """
     row_data = row.copy()
@@ -55,9 +56,9 @@ def row_to_enquiry(row: dict) -> Enquirer:
     # this is an optional field, if the value is blank ensure it gets default choice
     if row_data.get("marketing_channel") == "":
         row_data["marketing_channel"] = ref_data.MarketingChannel.DEFAULT
-    # this is an optional DateTime field, it needs to be set to 'None' to avoid errors
-    if row_data.get("date_received") == "":
-        row_data["date_received"] = None
+    # if date_received is not provided, set it to now
+    if not row_data.get("date_received"):
+        row_data["date_received"] = datetime.now()
 
     enquiry = Enquiry(enquirer=enquirer, **row_data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ pyparsing==2.4.5
 pytest==5.3.1
 pytest-cov==2.10.0
 pytest-django==3.7.0
+pytest-freezegun==0.4.2
 pytz==2019.3
 redis==3.4.1
 requests==2.22.0


### PR DESCRIPTION
## Description of change

When an enquiry is uploaded via CSV, rather than ingested through Activity stream, the date it was received is often not the same as the date the enquiry is created in the tool. In order to return the date received, there is currently a `received` property on the Enquiry model which will return `date_received` if populated and `created` if not. As we are now implementing sorting and as the app scales, making queries on this property is proving complex.

As a result, this PR automatically populates the `date_received` field when an enquiry is created.

If an enquiry is uploaded via CSV and there is no value in the `date_received` column, that value will be set to `datetime.now()`.

If an enquiry is ingested via Activity Stream, the `date_received` value will be set to the `published` value from Activity stream (which is the moment the original form is filled out on the invest in great website.

TODO:

1. Next: write a management command to populate all existing enquiries which don't have a value for `date_received` with their date created
2. Run this management command 
3. Once all enquiries in production have a value for `date_received`, remove the `received` property from the enquiry model and replace uses of it with references to the `date_received` field (e.g. in filters)
4. Implement the sortby feature which will at this point be able to order enquiries by `date_received`

## Test instructions

The app is only integrated with activity stream in production, but you can test that the date_received field is populated when an enquiry is uploaded via CSV by:
- Uploading an enquiry without a date_received ([google doc here](https://docs.google.com/spreadsheets/d/1Bng4CbGYJPewKBy_NhY00fEt3zcTXO90/edit#gid=1423515304))
- Open a shell in the docker container (`docker exec -it enquiry-mgmt-tool_app_1 bash`
- Open a django shell, find the enquiry you just created and check that it has a value for `date_received`