### PR TITLE
Add management command to fill date_received fields

### DIFF
--- a/app/enquiries/management/commands/fill_date_received.py
+++ b/app/enquiries/management/commands/fill_date_received.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from app.enquiries.models import Enquiry
+
+
+class Command(BaseCommand):
+    """
+    Command is for one-off use to populate the date_received value for existing enquiries,
+    replacing empty values with the date the record was created
+    """
+
+    help = "this command replaces empty date_received values for enquiries with the date created"
+
+    def handle(self, *args, **options):
+        print('Replacing empty date_received values')
+
+        entries = Enquiry.objects.select_for_update().filter(date_received=None)
+        with transaction.atomic():
+            for entry in entries:
+                entry.date_received = entry.created
+                print(entry.date_received)
+                entry.save()
+
+        print(f'Updated {len(entries)} enquiries')


### PR DESCRIPTION
## Description of change
We are updating the `date_received` value of an enquiry to default to the `created` value where it is not explicitly provided. This management command is a task to add this missing information for existing data.

## Test instructions

- Run this command locally with the default test data (e.g. `docker exec -it enquiry-mgmt-tool_app_1 python manage.py fill_date_received` )
- Open up a django shell and confirm that the data has been updated