### PR TITLE
Add sort by functionality

### DIFF
--- a/app/enquiries/fixtures/test_enquiries.json
+++ b/app/enquiries/fixtures/test_enquiries.json
@@ -81,7 +81,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2020-01-23T14:09:50"
         }
     },
     {
@@ -124,7 +125,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2017-10-29T01:17:25"
         }
     },
     {
@@ -167,7 +169,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2017-04-03T12:26:38"
         }
     },
     {
@@ -210,7 +213,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2018-11-16T23:30:11"
         }
     },
     {
@@ -253,7 +257,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2018-10-28T11:54:59"
         }
     },
     {
@@ -296,7 +301,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2018-12-16T11:53:32"
         }
     },
     {
@@ -339,7 +345,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2017-02-22T00:57:05"
         }
     },
     {
@@ -382,7 +389,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2018-06-28T13:23:10"
         }
     },
     {
@@ -425,7 +433,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2018-07-16T18:50:25"
         }
     },
     {
@@ -468,7 +477,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-12-13T13:04:32"
         }
     },
     {
@@ -511,7 +521,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2018-06-03T10:52:16"
         }
     },
     {
@@ -554,7 +565,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2020-01-23T08:06:18"
         }
     },
     {
@@ -597,7 +609,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2018-03-06T22:55:41"
         }
     },
     {
@@ -640,7 +653,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2020-02-21T08:25:50"
         }
     },
     {
@@ -683,7 +697,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2018-11-17T09:07:20"
         }
     },
     {
@@ -726,7 +741,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-15T18:10:06"
         }
     },
     {
@@ -769,7 +785,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2017-06-13T13:38:24"
         }
     },
     {
@@ -812,7 +829,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2018-12-09T12:52:42"
         }
     },
     {
@@ -855,7 +873,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2017-11-19T16:40:26"
         }
     },
     {
@@ -898,7 +917,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2017-02-27T06:37:18"
         }
     },
     {
@@ -941,7 +961,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2019-04-28T13:28:29"
         }
     },
     {
@@ -984,7 +1005,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2017-08-10T08:21:56"
         }
     },
     {
@@ -1027,7 +1049,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2019-12-24T20:39:48"
         }
     },
     {
@@ -1070,7 +1093,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2019-05-08T07:23:01"
         }
     },
     {
@@ -1113,7 +1137,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-22T08:14:38"
         }
     },
     {
@@ -1156,7 +1181,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2020-01-18T09:05:00"
         }
     },
     {
@@ -1199,7 +1225,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2018-12-15T10:29:20"
         }
     },
     {
@@ -1242,7 +1269,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2018-11-26T07:21:29"
         }
     },
     {
@@ -1285,7 +1313,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2019-03-24T15:32:06"
         }
     },
     {
@@ -1328,7 +1357,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2017-11-15T03:36:49"
         }
     },
     {
@@ -1371,7 +1401,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2017-01-15T07:28:04"
         }
     },
     {
@@ -1414,7 +1445,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2020-01-11T05:36:08"
         }
     },
     {
@@ -1457,7 +1489,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2018-09-07T07:38:38"
         }
     },
     {
@@ -1500,7 +1533,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2017-08-24T02:19:28"
         }
     },
     {
@@ -1543,7 +1577,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 2
+            "enquirer": 2,
+            "date_received": "2018-01-22T21:52:53"
         }
     },
     {
@@ -1586,7 +1621,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 3
+            "enquirer": 3,
+            "date_received": "2017-04-24T12:46:29"
         }
     },
     {
@@ -1629,7 +1665,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -1671,7 +1708,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -1713,7 +1751,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -1755,7 +1794,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -1797,7 +1837,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -1839,7 +1880,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -1881,7 +1923,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -1923,7 +1966,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -1965,7 +2009,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -2007,7 +2052,8 @@
             "date_added_to_datahub": "2020-02-03",
             "datahub_project_status": "ACTIVE",
             "project_success_date": "2022-02-03",
-            "enquirer": 1
+            "enquirer": 1,
+            "date_received": "2019-09-12T00:13:31"
         }
     },
     {
@@ -2136,7 +2182,7 @@
             "enquirer": 1,
             "date_received": "2017-01-01T00:13:31"
         }
-    }, 
+    },
     {
         "model": "enquiries.enquiry",
         "pk": 50,

--- a/app/enquiries/templates/enquiry_list.html
+++ b/app/enquiries/templates/enquiry_list.html
@@ -30,10 +30,31 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="collection-header__row">
+                        <div class="collection-header__row collection-header__row-no-border">
                             <div class="header-page-number-container">
                                 <span class="header-page-number">Page {{ current_page }} of {{ total_pages }}</span>
                             </div>
+                            <div class="sortby-container">
+                                <label for="sortby" class="govuk-label sortby-label">
+                                    Sort by
+                                </label>
+                                <select name="sortby" class="govuk-select sortby-select" onchange="window.location.href='{% url 'enquiry-list' %}?sortby=' + this.value">
+                                    <option value="name" {% if request.query_params.sortby == "name" %} selected {% endif %}>
+                                        Company name: A-Z
+                                    </option>
+                                    <option value="updated" {% if request.query_params.sortby == "updated" %} selected {% endif %}>
+                                            Most recently updated
+                                    </option>
+                                    <option value="received:asc" {% if request.query_params.sortby == "received:asc" %} selected {% endif %}>
+                                            Date received: old-new
+                                    </option>
+                                    <option value="received:desc" {% if request.query_params.sortby == "received:desc" %} selected {% endif %}>
+                                        Date received: new-old
+                                    </option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="collection-header__row">
                             <div class="download-button-container">
                                 <button
                                     onclick="location.search += (location.search ? '&' : '') + 'format=csv' "

--- a/app/enquiries/templates/enquiry_list.html
+++ b/app/enquiries/templates/enquiry_list.html
@@ -30,26 +30,22 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="collection-header__row collection-header__row-no-border">
+                        <div class="collection-header__row collection-header__row_no-border">
                             <div class="header-page-number-container">
                                 <span class="header-page-number">Page {{ current_page }} of {{ total_pages }}</span>
                             </div>
-                            <div class="sortby-container">
-                                <label for="sortby" class="govuk-label sortby-label">
+                            <div class="sortby">
+                                <label for="sortby" class="govuk-label sortby__label">
                                     Sort by
                                 </label>
-                                <select name="sortby" class="govuk-select sortby-select" onchange="window.location.href='{% url 'enquiry-list' %}?sortby=' + this.value">
-                                    <option value="name" {% if request.query_params.sortby == "name" %} selected {% endif %}>
-                                        Company name: A-Z
-                                    </option>
-                                    <option value="updated" {% if request.query_params.sortby == "updated" %} selected {% endif %}>
-                                            Most recently updated
-                                    </option>
-                                    <option value="received:asc" {% if request.query_params.sortby == "received:asc" %} selected {% endif %}>
-                                            Date received: old-new
-                                    </option>
-                                    <option value="received:desc" {% if request.query_params.sortby == "received:desc" %} selected {% endif %}>
-                                        Date received: new-old
+                                <select name="sortby" class="govuk-select sortby__select"  onchange="location.search += (location.search ? '&' : '') + 'sortby=' + this.value">
+                                    {% for key,value in sort_options.items %}
+                                        <option value="{{ key }}" {% if request.query_params.sortby == key %} selected {% endif %}>
+                                            {{ value }}
+                                        </option>
+                                    {% endfor %}
+                                    <option value="-date_received" {% if request.query_params.sortby|is_default_sort %} selected {% endif %}>
+                                        Most recently received
                                     </option>
                                 </select>
                             </div>

--- a/app/enquiries/templatetags/enquiries_extras.py
+++ b/app/enquiries/templatetags/enquiries_extras.py
@@ -179,3 +179,8 @@ def truncate_chars_end_word(value: str, max_length: int):
             truncd_val = truncd_val[:truncd_val.rfind(" ")]
         return truncd_val + "..."
     return value
+
+
+@register.filter
+def is_default_sort(sort_by):
+    return not sort_by or sort_by not in settings.ENQUIRY_SORT_OPTIONS.keys()

--- a/app/enquiries/tests/factories.py
+++ b/app/enquiries/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 import random
 
-from datetime import date
+from datetime import date, timezone
 from faker import Faker
 
 
@@ -88,6 +88,7 @@ class EnquiryFactory(factory.django.DjangoModelFactory):
     datahub_project_status = get_random_item(ref_data.DatahubProjectStatus)
     date_added_to_datahub = date.today()
     project_success_date = date.today()
+    date_received = factory.Faker("date_time", tzinfo=timezone.utc)
     client_relationship_manager = factory.Faker("first_name")
 
     class Meta:

--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -217,9 +217,10 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
         """
         num_enquiries = 123
         enquiries = EnquiryFactory.create_batch(num_enquiries)
+        # sort enquiries to match the default sort
+        enquiries.sort(key=lambda x: x.date_received, reverse=True)
         ids = [e.id for e in enquiries]
-        # reverse the ids because we order by latest first
-        ids = ids[::-1]
+
         page_size = settings.REST_FRAMEWORK["PAGE_SIZE"]
         total_pages = (num_enquiries + page_size - 1) // page_size
         for page in range(total_pages):
@@ -307,6 +308,7 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
         data["enquiry_stage"] = get_random_item(ref_data.EnquiryStage)
         data["notes"] = self.faker.sentence()
         data["country"] = get_random_item(ref_data.Country)
+        data["date_received"] = self.faker.date_time()
 
         # Enquirer fields are also sent in a single form update
         enquirer = enquiry_obj.enquirer

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -276,6 +276,17 @@ class EnquiryListView(LoginRequiredMixin, ListAPIView):
     pagination_class = PaginationWithPaginationMeta
 
     def get_queryset(self):
+        sortby = self.request.query_params.get("sortby")
+        all_enquiries = models.Enquiry.objects.all()
+        if sortby == "name":
+            return all_enquiries.order_by("company_name")
+        if sortby == "updated":
+            return all_enquiries.order_by("-modified")
+        if sortby == "received:asc":
+            return all_enquiries.order_by("date_received")
+        if sortby == "received:desc":
+            # Will work once every enquiry has a date received
+            return all_enquiries.order_by("-date_received")
         return models.Enquiry.objects.all()
 
     @property

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -102,6 +102,7 @@ class PaginationWithPaginationMeta(PageNumberPagination):
             "owners": models.Owner.objects.all().order_by("first_name"),
             "query_params": self.request.GET,
             "total_pages": len(self.page.paginator.page_range),
+            "sort_options": settings.ENQUIRY_SORT_OPTIONS,
             "pages": [
                 {
                     "page_number": page_number,
@@ -278,16 +279,10 @@ class EnquiryListView(LoginRequiredMixin, ListAPIView):
     def get_queryset(self):
         sortby = self.request.query_params.get("sortby")
         all_enquiries = models.Enquiry.objects.all()
-        if sortby == "name":
-            return all_enquiries.order_by("company_name")
-        if sortby == "updated":
-            return all_enquiries.order_by("-modified")
-        if sortby == "received:asc":
-            return all_enquiries.order_by("date_received")
-        if sortby == "received:desc":
-            # Will work once every enquiry has a date received
-            return all_enquiries.order_by("-date_received")
-        return models.Enquiry.objects.all()
+
+        return all_enquiries.order_by(
+            sortby if sortby in settings.ENQUIRY_SORT_OPTIONS.keys() else "-date_received"
+        )
 
     @property
     def is_csv(self):

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -230,6 +230,11 @@ SECURE_BROWSER_XSS_FILTER = True
 CHAR_FIELD_MAX_LENGTH = 255
 ENQUIRIES_PER_PAGE = env.int('ENQUIRIES_PER_PAGE', default=10)
 ENQUIRY_RESPONSIVENESS_PERIOD_WEEKS = env.int('ENQUIRY_RESPONSIVENESS_PERIOD_WEEKS', default=6)
+ENQUIRY_SORT_OPTIONS = {
+    "company_name": "Company name: A-Z",
+    "-modified": "Most recently updated",
+    "date_received": "Least recently received",
+}
 IMPORT_ENQUIRIES_MIME_TYPES = ["text/csv", "application/vnd.ms-excel"]
 IMPORT_TEMPLATE_FILENAME = 'rtt_enquiries_import_template.xlsx'
 IMPORT_TEMPLATE_MIMETYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'

--- a/cypress/e2e_tests/selectors/index.js
+++ b/cypress/e2e_tests/selectors/index.js
@@ -2,4 +2,5 @@ module.exports = {
   pagination: require('./pagination'),
   results: require('./results'),
   details: require('./details'),
+  sort: require('./sort')
 }

--- a/cypress/e2e_tests/selectors/sort.js
+++ b/cypress/e2e_tests/selectors/sort.js
@@ -1,0 +1,4 @@
+module.exports = {
+    selector: 'select.sortby__select',
+    companyName: '.entity__list-item a'
+}

--- a/cypress/e2e_tests/specs/sort.test.js
+++ b/cypress/e2e_tests/specs/sort.test.js
@@ -1,0 +1,49 @@
+require('../support/commands')
+const { assertSortedByDate } = require('../support/assertions')
+const { sort } = require('../selectors')
+
+const FIELDINDEXES = {
+  'date_received': 1,
+  'date_updated': 3,
+}
+
+const testDateSort = (searchString, fieldIndex, ascending) => {
+  context(`Sorting by ${searchString}`, () => {
+    it(`Should sort enquiries in ${ascending ? 'ascending': 'descending'} order`, () => {
+      cy.get(sort.selector).select(searchString)
+      assertSortedByDate(fieldIndex, ascending);
+    })
+  })
+}
+
+describe('Sorting enquiries list view', () => {
+  before(() => {
+    cy.reseed('/enquiries')
+  })
+  beforeEach(() => Cypress.Cookies.preserveOnce('sessionid'))
+
+  context('Viewing without explicit sorting', () => {
+    it('Should sort enquiries by newest date received', () => {
+      assertSortedByDate(FIELDINDEXES.date_received, false);
+    })
+  })
+
+  testDateSort('Most recently updated', FIELDINDEXES.date_updated, false)
+
+  testDateSort('Least recently received', FIELDINDEXES.date_received, true)
+
+  testDateSort('Most recently received', FIELDINDEXES.date_received, false)
+
+
+  context('Sorting by Company name: A-Z', () => {
+    it('Should sort enquiries in ascending order', () => {
+      cy.get(sort.selector).select('Company name: A-Z')
+
+      cy.get(sort.companyName)
+        .then(($els) => {
+          const names = $els.map($el => $el.text)
+          expect(names).to.eq(names.sort((a, b) => {a.localeCompare(b)}))
+        })
+    })
+  })
+})

--- a/cypress/e2e_tests/support/assertions.js
+++ b/cypress/e2e_tests/support/assertions.js
@@ -66,9 +66,18 @@ const assertEnquiryForm = specs => {
   })
 }
 
+const assertSortedByDate = (fieldIndex, ascending) => {
+  cy.get(`.entity__content-item:nth-child(${fieldIndex}) .list-item-value`)
+    .then(($els) => {
+      const dates = $els.map($el => Date.parse($el.text))
+      expect(dates).to.eq(dates.sort((a, b) => { ascending ? a < b : a > b }))
+    })
+}
+
 module.exports = {
   assertSummaryList,
   assertEnquiryForm,
   assertSummaryDetails,
+  assertSortedByDate,
   NOT_EDITABLE,
 }

--- a/sass/_enquiry_list.scss
+++ b/sass/_enquiry_list.scss
@@ -59,6 +59,11 @@ $govuk-assets-path: '/static/assets/';
     padding: govuk-spacing(3) 0;
     border-bottom: 1px solid #6f777b;
     margin-right: 0;
+    justify-content: space-between;
+}
+
+.collection-header__row-no-border {
+    border-bottom: none;
 }
 
 .filters__column {
@@ -86,3 +91,18 @@ $govuk-assets-path: '/static/assets/';
 .download-button-container {
     margin-left: auto;
 }
+<<<<<<< HEAD
+=======
+
+.sortby-select {
+    display: inline-block;
+}
+.sortby-container {
+    display: flex;
+    align-items: center;
+}
+
+.sortby-label {
+    margin-right: 8px;
+}
+>>>>>>> Sort enquiries in list view

--- a/sass/_enquiry_list.scss
+++ b/sass/_enquiry_list.scss
@@ -60,10 +60,10 @@ $govuk-assets-path: '/static/assets/';
     border-bottom: 1px solid #6f777b;
     margin-right: 0;
     justify-content: space-between;
-}
 
-.collection-header__row-no-border {
-    border-bottom: none;
+    &_no-border{
+        border-bottom: none;
+    }
 }
 
 .filters__column {
@@ -91,18 +91,15 @@ $govuk-assets-path: '/static/assets/';
 .download-button-container {
     margin-left: auto;
 }
-<<<<<<< HEAD
-=======
 
-.sortby-select {
-    display: inline-block;
-}
-.sortby-container {
+.sortby {
     display: flex;
     align-items: center;
-}
 
-.sortby-label {
-    margin-right: 8px;
+    &__select {
+        display: inline-block;
+    }
+    &__label {
+        margin-right: 8px;
+    }
 }
->>>>>>> Sort enquiries in list view


### PR DESCRIPTION
## Description of change
Adds an option to sort enquiries by different properties
As a default, enquiries will be sorted by date received, with the newest first.

<img width="646" alt="sort select" src="https://user-images.githubusercontent.com/23265724/90667408-a316f400-e246-11ea-93ac-2a903994176e.png">

## Test instructions
- When running locally, you will need to update SASS by running: `sh ./bootstrap.sh` to see expected styling
- Click on the 'Sort by' <select> to choose different options for sorting enquiry results; this sorting should be continued through to different pages of results