### PR TITLE
Enable editing 'Date Added to Data Hub' field

### DIFF
--- a/app/enquiries/templates/enquiry_edit.html
+++ b/app/enquiries/templates/enquiry_edit.html
@@ -252,10 +252,7 @@
                     {{ form.client_relationship_manager }}
                 </div>
 
-                <div class="read-only">
-                    <div class="govuk-label">Date added to Data Hub</div>
-                    <p>{{ enquiry|get_dh_date_added }}</p>
-                </div>
+                {% include 'snippets/enquiry_field_input_date.html' with instance=enquiry field="date_added_to_datahub" %}
 
                 {% include 'snippets/enquiry_field_input.html' with instance=enquiry field="project_code" %}
 

--- a/cypress/e2e_tests/specs/edit.test.js
+++ b/cypress/e2e_tests/specs/edit.test.js
@@ -403,9 +403,9 @@ describe('Edit', () => {
               value: 'Data Hub user 1',
             },
             {
-              type: NOT_EDITABLE,
+              type: 'date',
               label: 'Date added to Data Hub',
-              value: '03 February 2020',
+              value: '2020-02-03',
             },
             {
               type: 'text',
@@ -628,6 +628,11 @@ describe('Edit', () => {
           value: 'Data Hub user 2',
         },
         {
+          type: 'date',
+          name: 'date_added_to_datahub',
+          value: '2020-08-10',
+        },
+        {
           type: 'text',
           name: 'project_code',
           value: '67542',
@@ -772,7 +777,7 @@ describe('Edit', () => {
               dd: 'Business Partnership (Non-FDI)',
             },
             { dt: 'Client Relationship Manager', dd: 'Data Hub user 2' },
-            { dt: 'Date added to Data Hub', dd: 'Date not recorded' },
+            { dt: 'Date added to Data Hub', dd: '10 August 2020' },
             { dt: 'Project code', dd: '67542' },
             { dt: 'Data Hub project status', dd: 'Verify Win' },
             { dt: 'Project success date', dd: '01 February 2026' },


### PR DESCRIPTION
## Description of change

Allows users to edit the 'Date Added to Data Hub' field. Partly reverts: https://github.com/uktrade/enquiry-mgmt-tool/pull/157 (but preserves its changes improving empty field labelling and clarifying CSS class names).

## Test instructions
Select an enquiry, select 'edit', and try editing the 'Date Added to Data Hub' field