### PR TITLE
Update CSV field choices

### DIFF
--- a/app/enquiries/tests/test_views.py
+++ b/app/enquiries/tests/test_views.py
@@ -562,6 +562,15 @@ class EnquiryViewTestCase(test_utils.BaseEnquiryTestCase):
         response = self.client.get(reverse("enquiry-list"))
         assert response.get("Content-Disposition") is None
 
+    def test_enquiry_csv_response_fields(self):
+        """
+        Asserts that response to a ``format=csv`` request returns the expected enquiry fields.
+        """
+        response = self.client.get(reverse("enquiry-list"), dict(format="csv"))
+        assert response.content.decode().strip() == ','.join(
+            settings.EXPORT_OUTPUT_FILE_CSV_HEADERS
+        )
+
     @pytest.mark.skip(reason="@TODO need to investigate why the Owner model cannot be serialized")
     def test_enquiry_list_filtered_unassigned(self):
         """Test retrieving enquiry list and ensure we get expected count"""

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -251,6 +251,13 @@ class EnquiryFilter(filters.FilterSet):
         }
 
 
+class EnquiryListCSVRenderer(CSVRenderer):
+    """
+    A custom CSV renderer showing only selected fields.
+    """
+    header = settings.EXPORT_OUTPUT_FILE_CSV_HEADERS
+
+
 class EnquiryListView(LoginRequiredMixin, ListAPIView):
     """
     List all enquiries.
@@ -264,7 +271,7 @@ class EnquiryListView(LoginRequiredMixin, ListAPIView):
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = EnquiryFilter
     template_name = "enquiry_list.html"
-    renderer_classes = (TemplateHTMLRenderer, CSVRenderer)
+    renderer_classes = (TemplateHTMLRenderer, EnquiryListCSVRenderer)
     serializer_class = serializers.EnquiryDetailSerializer
     pagination_class = PaginationWithPaginationMeta
 

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -236,6 +236,17 @@ UPLOAD_CHUNK_SIZE = 256000
 EXPORT_OUTPUT_FILE_SLUG = 'rtt_enquiries_export'
 EXPORT_OUTPUT_FILE_EXT = 'csv'
 EXPORT_OUTPUT_FILE_MIMETYPE = 'text/csv'
+EXPORT_OUTPUT_FILE_CSV_HEADERS = [
+        'client_relationship_manager', 'company_name', 'country', 'created',
+        'datahub_project_status', 'date_added_to_datahub', 'date_received', 'enquirer.email',
+        'enquirer.email_consent', 'enquirer.first_name', 'enquirer.job_title',
+        'enquirer.last_name', 'enquirer.phone', 'enquirer.phone_consent',
+        'enquirer.phone_country_code', 'enquirer.request_for_call', 'enquiry_stage',
+        'enquiry_text', 'estimated_land_date', 'first_hpo_selection', 'first_response_channel',
+        'google_campaign', 'how_they_heard_dit', 'investment_readiness', 'investment_type',
+        'ist_sector', 'marketing_channel', 'notes', 'owner', 'owner.first_name', 'owner.last_name',
+        'primary_sector', 'project_code', 'project_name', 'project_success_date', 'quality',
+        'received', 'region', 'second_hpo_selection', 'third_hpo_selection', 'website']
 
 # Data Hub settings
 DATA_HUB_METADATA_URL = env('DATA_HUB_METADATA_URL')


### PR DESCRIPTION
## Description of change
Initially, too many fields were being returned to the users when they downloaded the Enquiry list summary CSV. Now only the expected fields are returned.

## Test instructions
From the homepage, click 'Download all'.
The first field displayed on the downloaded CSV should be: client_relationship_manager
The following fields should not be included:

- anonymised_project_description
- company_hq_address
- dh_assigned_company_name
- dh_company_address
- dh_company_id
- dh_company_number
- dh_duns_number
- enquirer.id
- id
- investor_involvement_level
- modified
- new_existing_investor
- organisation_type
- owner.date_joined
- owner.email
- owner.id
- owner.is_active
- owner.is_staff
- owner.is_superuser
- owner.last_login
- owner.password
- owner.username
- project_description
- specific_investment_programme