### PR TITLE
Change default port to 8001

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project uses Docker compose to setup and run all the necessary components. 
     docker-compose up --build
     ```
 
-You can view the app at `http://localhost:8000/enquiries/`
+You can view the app at `http://localhost:8001/enquiries/`
 
 The application uses SSO by default. When you access the above link for the first time you will be redirected to SSO login page. After authentication it will create a user in the database.
 
@@ -50,7 +50,7 @@ The app works out of the box with
 [mock-sso](https://github.com/uktrade/mock-sso), which is part of the
 docker-compose setup. The OAuth flow however only works locally when you
 set the `AUTHBROKER_URL` to
-[`host.docker.internal:8000`](http://docker.for.mac.localhost:8000/).
+[`host.docker.internal:8080`](http://docker.for.mac.localhost:8080/).
 This is because the SSO service (configured with the `AUTHBROKER_URL`) must be
 accessible from outside of docker-compose for the authorization redirect, and
 also from within docker-compose to make the access token POST request.

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "integrationFolder": "cypress/e2e_tests/specs/",
-  "baseUrl": "http://localhost:8000",
+  "baseUrl": "http://localhost:8001",
   "video": false,
   "videoUploadOnPasses": false,
   "screenshotOnRunFailure": false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,14 @@ services:
       - dh-api-mock
       - mock-sso
     ports:
-      - 8000:8000
+      - 8001:8001
     environment:
       ALLOW_TEST_FIXTURE_SETUP: allow
       DJANGO_SETTINGS_MODULE: app.settings.e2etest
       DJANGO_SUPERUSER_USERNAME: testuser
       DJANGO_SUPERUSER_EMAIL: testuser@example.com
       DJANGO_SUPERUSER_PASSWORD: testpass
-    entrypoint: dockerize -wait tcp://dh-api-mock:8001 -wait tcp://db:5432 -wait tcp://redis:6379 -timeout 5m
+    entrypoint: dockerize -wait tcp://dh-api-mock:8000 -wait tcp://db:5432 -wait tcp://redis:6379 -timeout 5m
     command: ./start.sh
 
   celery:
@@ -44,7 +44,7 @@ services:
   dh-api-mock:
     image: ukti/data-hub-sandbox:latest
     environment:
-      PORT: 8001
+      PORT: 8000
 
   mock-sso:
     image: ukti/mock-sso
@@ -60,5 +60,5 @@ services:
     depends_on:
       - app
     environment:
-      CYPRESS_BASE_URL: http://app:8000
+      CYPRESS_BASE_URL: http://app:8001
     entrypoint: cypress

--- a/sample_env
+++ b/sample_env
@@ -11,13 +11,13 @@ DJANGO_SENTRY_DSN=sentry-dsn
 ENQUIRIES_PER_PAGE=10
 
 # Data Hub variables
-DATA_HUB_METADATA_URL=http://dh-api-mock:8001/v4/metadata
-DATA_HUB_COMPANY_SEARCH_URL=http://dh-api-mock:8001/v4/search/company
-DATA_HUB_CONTACT_SEARCH_URL=http://dh-api-mock:8001/v3/search/contact
-DATA_HUB_CONTACT_CREATE_URL=http://dh-api-mock:8001/v3/contact
-DATA_HUB_INVESTMENT_CREATE_URL=http://dh-api-mock:8001/v3/investment
-DATA_HUB_ADVISER_SEARCH_URL=http://dh-api-mock:8001/adviser/
-DATA_HUB_WHOAMI_URL=http://dh-api-mock:8001/whoami
+DATA_HUB_METADATA_URL=http://dh-api-mock:8000/v4/metadata
+DATA_HUB_COMPANY_SEARCH_URL=http://dh-api-mock:8000/v4/search/company
+DATA_HUB_CONTACT_SEARCH_URL=http://dh-api-mock:8000/v3/search/contact
+DATA_HUB_CONTACT_CREATE_URL=http://dh-api-mock:8000/v3/contact
+DATA_HUB_INVESTMENT_CREATE_URL=http://dh-api-mock:8000/v3/investment
+DATA_HUB_ADVISER_SEARCH_URL=http://dh-api-mock:8000/adviser/
+DATA_HUB_WHOAMI_URL=http://dh-api-mock:8000/whoami
 DATA_HUB_FRONTEND=https://datahub/frontend
 DATA_HUB_CREATE_COMPANY_PAGE_URL=https://www.datahub.dev.uktrade.io/companies/create
 

--- a/start.sh
+++ b/start.sh
@@ -2,4 +2,4 @@
 
 python manage.py migrate
 sh setup-test-fixtures.sh
-python manage.py runserver 0.0.0.0:8000
+python manage.py runserver 0.0.0.0:8001


### PR DESCRIPTION
## Description of change
Currently, the default settings for running the project have the default port as 8000 - this causes a conflict with the default Data Hub API port in local development. 

This PR updates that default port to 8001.

## Test instructions
Make sure the Data Hub API is running locally on 8000; then rebuild and start this project and check it is running locally at localhost:8001