### PR TITLE
Hide data hub project status field

### DIFF
--- a/app/enquiries/forms.py
+++ b/app/enquiries/forms.py
@@ -48,4 +48,4 @@ class EnquiryForm(ModelForm):
 
     class Meta:
         model = Enquiry
-        fields = "__all__"
+        exclude = ('datahub_project_status',)

--- a/app/enquiries/serializers.py
+++ b/app/enquiries/serializers.py
@@ -79,7 +79,6 @@ class EnquiryDetailSerializer(serializers.ModelSerializer):
         source="get_specific_investment_programme_display"
     )
     date_added_to_datahub = serializers.DateField(format="%d %B %Y")
-    datahub_project_status = serializers.CharField(source="get_datahub_project_status_display")
     project_success_date = serializers.DateField(format="%d %B %Y")
     received = serializers.DateTimeField(format="%d %B %Y")
 

--- a/app/enquiries/templates/enquiry_detail.html
+++ b/app/enquiries/templates/enquiry_detail.html
@@ -167,7 +167,6 @@
                     <dd class="govuk-summary-list__value"  id="{{ date_added_to_datahub }}">{{ enquiry|get_dh_date_added }}</dd>
                 </div>
                 {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="project_code" %}
-                {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="datahub_project_status" %}
                 {% include 'snippets/summary_list_key_value.html' with instance=enquiry field="project_success_date" %}
             </dl>
         </div>

--- a/app/enquiries/templates/enquiry_edit.html
+++ b/app/enquiries/templates/enquiry_edit.html
@@ -256,9 +256,6 @@
 
                 {% include 'snippets/enquiry_field_input.html' with instance=enquiry field="project_code" %}
 
-                <!-- TODO: Change label to 'Data Hub project status' -->
-                {% include 'snippets/enquiry_field_select.html' with instance=enquiry field="datahub_project_status" %}
-
                 {% include 'snippets/enquiry_field_input_date.html' with instance=enquiry field="project_success_date" %}
 
                  {% include 'snippets/enquiry_field_textarea.html' with instance=enquiry field="notes" %}

--- a/app/enquiries/templatetags/enquiries_extras.py
+++ b/app/enquiries/templatetags/enquiries_extras.py
@@ -35,7 +35,6 @@ can_be_default_fields = [
     "third_hpo_selection",
     "organisation_type",
     "new_existing_investor",
-    "datahub_project_status",
 ]
 
 field_error_msgs = {

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -238,7 +238,7 @@ EXPORT_OUTPUT_FILE_EXT = 'csv'
 EXPORT_OUTPUT_FILE_MIMETYPE = 'text/csv'
 EXPORT_OUTPUT_FILE_CSV_HEADERS = [
         'client_relationship_manager', 'company_name', 'country', 'created',
-        'datahub_project_status', 'date_added_to_datahub', 'date_received', 'enquirer.email',
+        'date_added_to_datahub', 'date_received', 'enquirer.email',
         'enquirer.email_consent', 'enquirer.first_name', 'enquirer.job_title',
         'enquirer.last_name', 'enquirer.phone', 'enquirer.phone_consent',
         'enquirer.phone_country_code', 'enquirer.request_for_call', 'enquiry_stage',

--- a/cypress/e2e_tests/specs/edit.test.js
+++ b/cypress/e2e_tests/specs/edit.test.js
@@ -146,7 +146,6 @@ describe('Edit', () => {
             { dt: 'Client Relationship Manager', dd: 'Data Hub user 1' },
             { dt: 'Date added to Data Hub', dd: '03 February 2020' },
             { dt: 'Project code', dd: '42901' },
-            { dt: 'Data Hub project status', dd: 'Active' },
             { dt: 'Project success date', dd: '03 February 2022' },
           ],
         },
@@ -413,11 +412,6 @@ describe('Edit', () => {
               value: '42901',
             },
             {
-              type: 'select',
-              label: 'Data Hub project status',
-              value: 'ACTIVE',
-            },
-            {
               type: 'date',
               label: 'Project success date',
               value: '2022-02-03',
@@ -638,11 +632,6 @@ describe('Edit', () => {
           value: '67542',
         },
         {
-          type: 'select',
-          name: 'datahub_project_status',
-          value: 'VERIFY',
-        },
-        {
           type: 'date',
           name: 'project_success_date',
           value: '2026-02-01',
@@ -779,7 +768,6 @@ describe('Edit', () => {
             { dt: 'Client Relationship Manager', dd: 'Data Hub user 2' },
             { dt: 'Date added to Data Hub', dd: '10 August 2020' },
             { dt: 'Project code', dd: '67542' },
-            { dt: 'Data Hub project status', dd: 'Verify Win' },
             { dt: 'Project success date', dd: '01 February 2026' },
           ],
         },


### PR DESCRIPTION
## Description of change

This PR hides the field `data_hub_project_status` from users as it is no longer needed. It has not been removed from the model as some enquiries in the prod database already have this field populated and users do not want to lose this data. 

The field will still be able to be edited through django admin if needed.

## Test instructions

The field should no longer appear in the following places:
- View an enquiry
- Edit an enquiry
- The CSV download in the list view