### PR TITLE
Add command to mark stale enquiries as 'Non-responsive'

### DIFF
--- a/app/enquiries/celery.py
+++ b/app/enquiries/celery.py
@@ -15,6 +15,8 @@ app.autodiscover_tasks()
 
 DH_METADATA_FETCH_INTERVAL_HOURS = settings.DATA_HUB_METADATA_FETCH_INTERVAL_HOURS
 AS_ENQUIRIES_POLL_INTERVAL_MINS = settings.ACTIVITY_STREAM_ENQUIRY_POLL_INTERVAL_MINS
+ENQUIRY_STATUS_UPDATE_INTERVAL_DAYS = settings.ENQUIRY_STATUS_UPDATE_INTERVAL_DAYS
+ENQUIRY_STATUS_SHOULD_UPDATE = settings.ENQUIRY_STATUS_SHOULD_UPDATE
 
 app.conf.beat_schedule = {
     "refresh-datahub-metadata": {
@@ -25,4 +27,17 @@ app.conf.beat_schedule = {
         "task": "fetch_new_enquiries",
         "schedule": crontab(minute=f"*/{AS_ENQUIRIES_POLL_INTERVAL_MINS}"),
     },
+    "update-stage-stale-enquiries": {
+        "task": "update_stage_stale_enquiries",
+        "schedule": crontab(day_of_month=f"*/{ENQUIRY_STATUS_UPDATE_INTERVAL_DAYS}")
+    }
+} if ENQUIRY_STATUS_SHOULD_UPDATE else {
+    "refresh-datahub-metadata": {
+        "task": "refresh_datahub_metadata",
+        "schedule": crontab(minute="0", hour=f"*/{DH_METADATA_FETCH_INTERVAL_HOURS}"),
+    },
+    "fetch-new-enquiries": {
+        "task": "fetch_new_enquiries",
+        "schedule": crontab(minute=f"*/{AS_ENQUIRIES_POLL_INTERVAL_MINS}"),
+    }
 }

--- a/app/enquiries/management/commands/mark_non_responsive_enquiries.py
+++ b/app/enquiries/management/commands/mark_non_responsive_enquiries.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from app.enquiries.utils import mark_non_responsive_enquiries
+
+
+class Command(BaseCommand):
+    """
+    Command is to mark enquries as 'Non-Responsive' if a company has not responded to the team and
+    the enquiry has not been updated in six weeks.
+    """
+
+    help = """
+        this command finds enquiries not edited in six weeks that have the 'Awaiting Response'
+        enquiry stage and updates this to 'Non-Responsive'
+    """
+
+    def handle(self, *args, **options):
+        mark_non_responsive_enquiries(expiry_weeks=settings.ENQUIRY_RESPONSIVENESS_PERIOD_WEEKS)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"""
+                    Successfully updated enquiries older than
+                    {settings.ENQUIRY_RESPONSIVENESS_PERIOD_WEEKS} weeks
+                """
+            )
+        )

--- a/app/enquiries/tasks.py
+++ b/app/enquiries/tasks.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from app.enquiries.celery import app
 from app.enquiries.common.datahub_utils import dh_fetch_metadata
 from app.enquiries.common.as_utils import fetch_and_process_enquiries
+from app.enquiries.utils import mark_non_responsive_enquiries
 
 FETCH_INTERVAL_HOURS = f"*/{settings.DATA_HUB_METADATA_FETCH_INTERVAL_HOURS}"
 
@@ -27,3 +28,11 @@ def fetch_new_enquiries():
 
     fetch_and_process_enquiries()
     logging.info(f"New enquiries last retrieved at {datetime.now()}")
+
+
+@app.task(name="update_stage_stale_enquiries")
+def update_stage_stale_enquiries():
+    """ Periodically changes older enquiries from 'Awaiting Response' to 'Non-responsive' """
+
+    mark_non_responsive_enquiries(expiry_weeks=settings.ENQUIRY_RESPONSIVENESS_PERIOD_WEEKS)
+    logging.info(f"Older enquiries marked as 'Non-responsive' at {datetime.now()}")

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -229,6 +229,7 @@ SECURE_BROWSER_XSS_FILTER = True
 # App specific settings
 CHAR_FIELD_MAX_LENGTH = 255
 ENQUIRIES_PER_PAGE = env.int('ENQUIRIES_PER_PAGE', default=10)
+ENQUIRY_RESPONSIVENESS_PERIOD_WEEKS = env.int('ENQUIRY_RESPONSIVENESS_PERIOD_WEEKS', default=6)
 IMPORT_ENQUIRIES_MIME_TYPES = ["text/csv", "application/vnd.ms-excel"]
 IMPORT_TEMPLATE_FILENAME = 'rtt_enquiries_import_template.xlsx'
 IMPORT_TEMPLATE_MIMETYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
@@ -281,6 +282,8 @@ if REDIS_BASE_URL:
     BROKER_URL = f'{REDIS_BASE_URL}/{REDIS_CELERY_DB}?{encoded_query_args}'
     CELERY_RESULT_BACKEND = BROKER_URL
     CELERY_TIMEZONE = env('CELERY_TIMEZONE', default='Europe/london')
+    ENQUIRY_STATUS_UPDATE_INTERVAL_DAYS = env.int('ENQUIRY_STATUS_UPDATE_INTERVAL_DAYS', default=1)
+    ENQUIRY_STATUS_SHOULD_UPDATE = env.bool('ENQUIRY_STATUS_SHOULD_UPDATE', True)
 
     CACHES = {
         "default": {

--- a/sample_env
+++ b/sample_env
@@ -9,6 +9,7 @@ DATABASE_URL=postgres://postgres:password@db:5432/postgres
 DJANGO_SENTRY_DSN=sentry-dsn
 
 ENQUIRIES_PER_PAGE=10
+ENQUIRY_RESPONSIVENESS_PERIOD_WEEKS=6
 
 # Data Hub variables
 DATA_HUB_METADATA_URL=http://dh-api-mock:8000/v4/metadata
@@ -28,7 +29,9 @@ DATA_HUB_HAWK_KEY=hawk-key
 
 # Celery and Redis
 DATA_HUB_METADATA_FETCH_INTERVAL=4      # in hours
-REDIS_BASE_URL=redis://localhost:6379
+ENQUIRY_STATUS_UPDATE_INTERVAL_DAYS=1
+ENQUIRY_STATUS_SHOULD_UPDATE=0
+REDIS_BASE_URL=redis://redis:6379
 CELERY_TIMEZONE=Europe/london
 
 # Staff SSO/OAuth2 settings


### PR DESCRIPTION
## Description of change
Adds a command that checks whether an enquiry has not been updated in six weeks and has a status of 'Awaiting response'. In this case, the enquiry is marked as 'Non responsive'.

Also adds a celery task to run this command daily.

## Test instructions
If running locally, check the numbers of enquiries with 'Awaiting response' and 'Non responsive' added using the filters.
Run the command with `python manage.py mark_non_responsive_enquiries`, and note the number of enquiries changed.
Check the new number of enquiries with 'Awaiting response' and 'Non responsive'. 