### PR TITLE
Replace received property with date_received field

### DIFF
--- a/app/enquiries/forms.py
+++ b/app/enquiries/forms.py
@@ -48,4 +48,4 @@ class EnquiryForm(ModelForm):
 
     class Meta:
         model = Enquiry
-        exclude = ('datahub_project_status',)
+        exclude = ('datahub_project_status', 'date_received')

--- a/app/enquiries/models.py
+++ b/app/enquiries/models.py
@@ -245,11 +245,6 @@ class Enquiry(TimeStampedModel):
         help_text="Address of the company in Data Hub",
     )
 
-    # Handles cases where the optional date_received field is not set.
-    @property
-    def received(self):
-        return self.date_received or self.created
-
     class Meta:
         ordering = ["-created"]
         verbose_name_plural = "Enquiries"

--- a/app/enquiries/serializers.py
+++ b/app/enquiries/serializers.py
@@ -80,7 +80,7 @@ class EnquiryDetailSerializer(serializers.ModelSerializer):
     )
     date_added_to_datahub = serializers.DateField(format="%d %B %Y")
     project_success_date = serializers.DateField(format="%d %B %Y")
-    received = serializers.DateTimeField(format="%d %B %Y")
+    date_received = serializers.DateTimeField(format="%d %B %Y")
 
     class Meta:
         model = models.Enquiry

--- a/app/enquiries/templates/enquiry_delete.html
+++ b/app/enquiries/templates/enquiry_delete.html
@@ -38,7 +38,7 @@
                     <dt class="govuk-summary-list__key">
                         Date received
                     </dt>
-                    <dd class="govuk-summary-list__value">{{ enquiry|get_field_value:"received" }}</dd>
+                    <dd class="govuk-summary-list__value">{{ enquiry|get_field_value:"date_received" }}</dd>
                 </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">

--- a/app/enquiries/templates/enquiry_detail.html
+++ b/app/enquiries/templates/enquiry_detail.html
@@ -54,7 +54,7 @@
                     <dt class="govuk-summary-list__key">
                         Date received
                     </dt>
-                    <dd class="govuk-summary-list__value">{{ enquiry|get_field_value:"received" }}</dd>
+                    <dd class="govuk-summary-list__value">{{ enquiry|get_field_value:"date_received" }}</dd>
                 </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">

--- a/app/enquiries/templates/enquiry_edit.html
+++ b/app/enquiries/templates/enquiry_edit.html
@@ -48,7 +48,7 @@
                     <dt class="govuk-summary-list__key">
                         Date received
                     </dt>
-                    <dd class="govuk-summary-list__value">{{ enquiry|get_field_value:"received" }}</dd>
+                    <dd class="govuk-summary-list__value">{{ enquiry|get_field_value:"date_received" }}</dd>
                 </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">

--- a/app/enquiries/templates/snippets/enquiry_item.html
+++ b/app/enquiries/templates/snippets/enquiry_item.html
@@ -27,7 +27,7 @@
             <div class="entity__content-list">
                 <div class="entity__content-item">
                     <span class="list-item-label">Date received</span>
-                    <span class="list-item-value">{{ enquiry.received }}</span>
+                    <span class="list-item-value">{{ enquiry.date_received }}</span>
                 </div>
                 <div class="entity__content-item">
                     <span class="list-item-label">Enquiry text</span>

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -224,18 +224,20 @@ class EnquiryFilter(filters.FilterSet):
 
     def filter_received_lt(self, queryset, name, value):
         """
-        Returns a queryset only with entities having the ``received`` date less than ``value``.
+        Returns a queryset with entities which have a ``date_received``
+        less than ``value``.
         """
         received = datetime.combine(value, datetime.min.time())
-        q = Q(date_received__lt=received) | Q(date_received__isnull=True, created__lt=received,)
+        q = Q(date_received__lt=received)
         return queryset.filter(q)
 
     def filter_received_gt(self, queryset, name, value):
         """
-        Returns a queryset only with entities having the ``received`` date greater than ``value``.
+        Returns a queryset with entities which have a ``date_received``
+        greater than ``value``.
         """
         received = datetime.combine(value, datetime.min.time())
-        q = Q(date_received__gt=received) | Q(date_received__isnull=True, created__gt=received,)
+        q = Q(date_received__gt=received)
         return queryset.filter(q)
 
     class Meta:

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -252,7 +252,7 @@ EXPORT_OUTPUT_FILE_CSV_HEADERS = [
         'google_campaign', 'how_they_heard_dit', 'investment_readiness', 'investment_type',
         'ist_sector', 'marketing_channel', 'notes', 'owner', 'owner.first_name', 'owner.last_name',
         'primary_sector', 'project_code', 'project_name', 'project_success_date', 'quality',
-        'received', 'region', 'second_hpo_selection', 'third_hpo_selection', 'website']
+        'region', 'second_hpo_selection', 'third_hpo_selection', 'website']
 
 # Data Hub settings
 DATA_HUB_METADATA_URL = env('DATA_HUB_METADATA_URL')


### PR DESCRIPTION
## Description of change

This PR follows two previous ones (#170 & #171) which populate the `date_received` field for an enquiry with the date created, if a manual `date_received` value is not given. 

Now that all enquiries have a value for `date_received` we can remove the `received` property from the Enquiry model and, wherever it was used, refer to the `date_received` field instead.

## Test instructions

There should be no visible changes, all tests should pass.