### PR TITLE
Add padding below summary list keys

### DIFF
--- a/sass/_enquiry_detail.scss
+++ b/sass/_enquiry_detail.scss
@@ -18,4 +18,7 @@ $govuk-assets-path: '/static/assets/';
 
 .govuk-summary-list {
     border-top: 2px solid govuk-colour("mid-grey");
+    &__key {
+        padding-bottom: 9.5px;
+    }
 }


### PR DESCRIPTION
## Description of change

Currently if a summary list key in an enquiry detail view goes onto a second line, there is no padding below the second line of text. This PR adds padding to the bottom of these labels. 

## Test instructions

- Run `npm run sass` to update the css
- Hard refresh the page
- Ensure the keys have a bottom padding of `9.5px`

**Before**

![Screenshot 2020-08-25 at 11 48 00](https://user-images.githubusercontent.com/22460823/91165598-d59e7200-e6c8-11ea-8f5c-56ced154c243.png)

**After**

![Screenshot 2020-08-25 at 11 48 18](https://user-images.githubusercontent.com/22460823/91165620-dfc07080-e6c8-11ea-9552-c2aa15c85c60.png)
