### PR TITLE
Make owner filter width match other filters

### DIFF
--- a/app/enquiries/templates/enquiry_list.html
+++ b/app/enquiries/templates/enquiry_list.html
@@ -8,7 +8,7 @@
         <h2 class="govuk-heading-l">Enquiries</h2>
         <div class="govuk-grid-row">
 
-            <div class="govuk-grid-column-one-third filters-column">
+            <div class="govuk-grid-column-one-third filters__column">
                 {% include 'partials/enquiry_filters.html' %}
             </div>
 

--- a/app/enquiries/templates/partials/enquiry_filters.html
+++ b/app/enquiries/templates/partials/enquiry_filters.html
@@ -7,7 +7,7 @@
         Owner
       </label>
 
-      <select class="govuk-select" id="owner__id" name="owner__id">
+      <select class="govuk-select filters__select" id="owner__id" name="owner__id">
         <option selected>---</option>
         <option value="UNASSIGNED" {% query_params_value_selected 'UNASSIGNED' 'owner__id' query_params ' selected'  %}>
           Unassigned

--- a/sass/_enquiry_list.scss
+++ b/sass/_enquiry_list.scss
@@ -65,6 +65,10 @@ $govuk-assets-path: '/static/assets/';
     padding: 0;
 }
 
+.filters__select {
+    width: 100%;
+}
+
 .import-enquiries-button {
     float: right;
     margin-bottom: 0;
@@ -81,4 +85,9 @@ $govuk-assets-path: '/static/assets/';
 
 .download-button-container {
     margin-left: auto;
+}
+
+// Make select element for owner filter same width as other filters
+.owner-filter {
+    width: 100%;
 }

--- a/sass/_enquiry_list.scss
+++ b/sass/_enquiry_list.scss
@@ -61,7 +61,7 @@ $govuk-assets-path: '/static/assets/';
     margin-right: 0;
 }
 
-.filters-column {
+.filters__column {
     padding: 0;
 }
 
@@ -85,9 +85,4 @@ $govuk-assets-path: '/static/assets/';
 
 .download-button-container {
     margin-left: auto;
-}
-
-// Make select element for owner filter same width as other filters
-.owner-filter {
-    width: 100%;
 }


### PR DESCRIPTION
## Description of change

This PR makes the width of the 'Owner' filter on the homepage the same width as the other filters by overriding the `max-width: 100%` on `govuk-select`. 

I have added a new `owner-filter` class instead of adding the width directly to `govuk-select` because that is used by selects in the edit form which do not need a width of `100%`.

## Test instructions

- Run `npm run sass` to update the css
- Hard refresh the page
- Check that the owner filter is the same width as the others

**Before**
![Screenshot 2020-08-25 at 12 17 58](https://user-images.githubusercontent.com/22460823/91168136-0680a600-e6cd-11ea-8156-f1c1c5ebe76e.png)

**After**
![Screenshot 2020-08-25 at 12 18 25](https://user-images.githubusercontent.com/22460823/91168166-15675880-e6cd-11ea-87f9-eb7e81e15597.png)
