### PR TITLE
Fix padding for summary list key items

### DIFF
--- a/sass/_enquiry_detail.scss
+++ b/sass/_enquiry_detail.scss
@@ -19,6 +19,6 @@ $govuk-assets-path: '/static/assets/';
 .govuk-summary-list {
     border-top: 2px solid govuk-colour("mid-grey");
     &__key {
-        padding-bottom: 9.5px;
+        padding-left: govuk-spacing(2);
     }
 }

--- a/sass/_settings.scss
+++ b/sass/_settings.scss
@@ -38,7 +38,3 @@ ol {
 .govuk-label {
     font-weight: bold;
 }
-
-.govuk-summary-list__key {
-    padding: 0 0.5em;
-}


### PR DESCRIPTION
## Description of change

When an item in the enquiry details summary list has no value, the key text doesn't have any top padding, this PR removes the override padding added previously which had caused this problem, and adds just padding to the left of the text.

## Test instructions

- Remove the 'website' value from one of the test fixtures
- Run `npm run sass`
- Hard refresh the page
- Go to an enquiry's details page and check that the website label has padding above it

**Before**
![Screenshot 2020-08-25 at 15 33 46](https://user-images.githubusercontent.com/22460823/91187713-60db3000-e6e8-11ea-8cfc-a395ddb4847e.png)

**After**
![Screenshot 2020-08-25 at 15 34 40](https://user-images.githubusercontent.com/22460823/91187823-7fd9c200-e6e8-11ea-9e87-c684b768881c.png)
