### PR TITLE
Use reference data in utility function to update stale enquiries

### DIFF
--- a/app/enquiries/utils.py
+++ b/app/enquiries/utils.py
@@ -159,13 +159,13 @@ def mark_non_responsive_enquiries(expiry_weeks):
     logging.info(f"Updating non-responsive enquiries from before {past_date}")
 
     entries = Enquiry.objects.select_for_update().filter(
-        modified__lt=past_date, enquiry_stage="AWAITING_RESPONSE"
+        modified__lt=past_date, enquiry_stage=ref_data.EnquiryStage.AWAITING_RESPONSE
     )
 
     with transaction.atomic():
         for entry in entries:
             logging.info(f"Updating enquiry last updated on {entry.modified}")
-            entry.enquiry_stage = "NON_RESPONSIVE"
+            entry.enquiry_stage = ref_data.EnquiryStage.NON_RESPONSIVE
             entry.save()
 
     logging.info(f"Updated enquiry stage of {len(entries)} enquiries")


### PR DESCRIPTION
## Description of change

Patch for https://github.com/uktrade/enquiry-mgmt-tool/pull/178 to use reference data rather than strings for checking and updating enquiries

## Test instructions
If `ENQUIRY_STATUS_SHOULD_UPDATE=1` locally, the Celery task `update-stage-stale-enquiries` should run successfully.