### PR TITLE
Replace enquiry-list route with index

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project uses Docker compose to setup and run all the necessary components. 
     docker-compose up --build
     ```
 
-You can view the app at `http://localhost:8001/enquiries/`
+You can view the app at `http://localhost:8001`
 
 The application uses SSO by default. When you access the above link for the first time you will be redirected to SSO login page. After authentication it will create a user in the database.
 

--- a/app/enquiries/templates/enquiry_detail.html
+++ b/app/enquiries/templates/enquiry_detail.html
@@ -8,7 +8,7 @@
 
     <div class="top-controls">
         <div class="top-controls__back-container">
-            <a href="{% url 'enquiry-list' %}" class="govuk-back-link">Back</a>
+            <a href="{% url 'index' %}" class="govuk-back-link">Back</a>
         </div>
         <div class="top-controls__edit-button-container">
             <a href="{% url 'enquiry-edit' enquiry.id %}" class="govuk-button

--- a/app/enquiries/templates/enquiry_import.html
+++ b/app/enquiries/templates/enquiry_import.html
@@ -7,7 +7,7 @@
 <div class="govuk-width-container">
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break">
 
-    <a href="{% url 'enquiry-list' %}" class="govuk-back-link">Back</a>
+    <a href="{% url 'index' %}" class="govuk-back-link">Back</a>
     <div class="govuk-grid-row">
     <h1 class="govuk-heading-l import-enquiries-heading">Import enquiries</h1>
     {% if messages %}

--- a/app/enquiries/templates/import-enquiries-confirmation.html
+++ b/app/enquiries/templates/import-enquiries-confirmation.html
@@ -5,7 +5,7 @@
 <div class="govuk-width-container">
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break">
 
-    <a href="{% url 'enquiry-list' %}" class="govuk-back-link">Back</a>
+    <a href="{% url 'index' %}" class="govuk-back-link">Back</a>
 
     <h3>Summary of {{enquiries|length}} imported records</h3>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break">

--- a/app/enquiries/templates/index.html
+++ b/app/enquiries/templates/index.html
@@ -9,7 +9,7 @@
     </div>
     <div class="govuk-grid-row">
       <p>
-        If you are not automatically redirected to the enquiries page, <a class="govuk-link" href="{% url 'enquiry-list' %}">click here.</a>
+        If you are not automatically redirected to the enquiries page, <a class="govuk-link" href="{% url 'index' %}">click here.</a>
       </p>
     </div>
   </main>

--- a/app/enquiries/templates/partials/enquiry_filters.html
+++ b/app/enquiries/templates/partials/enquiry_filters.html
@@ -1,5 +1,5 @@
 {% load enquiries_extras %}
-<form method="GET" action="{% url 'enquiry-list' %}" data-qa="search-filters">
+<form method="GET" action="{% url 'index' %}" data-qa="search-filters">
   {% include 'snippets/enquiry_field_checkbox.html' with group_id='enquiry_stage_container' heading='Enquiry stage' field=filter_enquiry_stage query_params=query_params %}
   <div class="govuk-form-group" id="users" data-qa="search-filter-users">
     <fieldset class="govuk-fieldset">
@@ -59,7 +59,7 @@
   <button id="btn_submit" class="govuk-button govuk-!-margin-right-1" data-module="govuk-button" accesskey="s">
     Apply filters
   </button>
-  <a href="{% url 'enquiry-list' %}" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="btn_clear" type="button" accesskey="c">
+  <a href="{% url 'index' %}" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="btn_clear" type="button" accesskey="c">
     Clear filters
   </a>
 </form>

--- a/app/enquiries/templates/partials/govuk_header_partial.html
+++ b/app/enquiries/templates/partials/govuk_header_partial.html
@@ -2,7 +2,7 @@
 <header class="govuk-header " role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__content">
-            <a href="{% url 'enquiry-list' %}" class="govuk-header__link govuk-header__link--service-name">
+            <a href="{% url 'index' %}" class="govuk-header__link govuk-header__link--service-name">
                 Ready to Trade
             </a>
             <strong class="govuk-tag">

--- a/app/enquiries/tests/test_filters.py
+++ b/app/enquiries/tests/test_filters.py
@@ -19,7 +19,7 @@ class EnquiryViewFiltersTestCase(test_utils.BaseEnquiryTestCase):
         # DRF defaults to JSON response so we need to set headers to
         # receive HTML
 
-        response = self.client.get(reverse("enquiry-list"), **headers)
+        response = self.client.get(reverse("index"), **headers)
         soup = BeautifulSoup(response.content, "html.parser")
 
         self.assertIsNotNone(

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -227,10 +227,7 @@ class EnquiryFilter(filters.FilterSet):
         Returns a queryset only with entities having the ``received`` date less than ``value``.
         """
         received = datetime.combine(value, datetime.min.time())
-        q = Q(date_received__lt=received) | Q(
-                date_received__isnull=True,
-                created__lt=received,
-            )
+        q = Q(date_received__lt=received) | Q(date_received__isnull=True, created__lt=received,)
         return queryset.filter(q)
 
     def filter_received_gt(self, queryset, name, value):
@@ -238,10 +235,7 @@ class EnquiryFilter(filters.FilterSet):
         Returns a queryset only with entities having the ``received`` date greater than ``value``.
         """
         received = datetime.combine(value, datetime.min.time())
-        q = Q(date_received__gt=received) | Q(
-            date_received__isnull=True,
-            created__gt=received,
-        )
+        q = Q(date_received__gt=received) | Q(date_received__isnull=True, created__gt=received,)
         return queryset.filter(q)
 
     class Meta:
@@ -256,6 +250,7 @@ class EnquiryListCSVRenderer(CSVRenderer):
     """
     A custom CSV renderer showing only selected fields.
     """
+
     header = settings.EXPORT_OUTPUT_FILE_CSV_HEADERS
 
 
@@ -303,7 +298,7 @@ class EnquiryListView(LoginRequiredMixin, ListAPIView):
         if self.is_csv:
             fname = settings.EXPORT_OUTPUT_FILE_SLUG
             ext = settings.EXPORT_OUTPUT_FILE_EXT
-            response['Content-Disposition'] = f"attachment; filename={fname}.{ext}"
+            response["Content-Disposition"] = f"attachment; filename={fname}.{ext}"
 
         return response
 
@@ -334,7 +329,7 @@ class EnquiryDetailView(LoginRequiredMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         enquiry = get_object_or_404(models.Enquiry, pk=kwargs["pk"])
         context["enquiry"] = enquiry
-        context["back_url"] = reverse("enquiry-list")
+        context["back_url"] = reverse("index")
         return context
 
     def post(self, request, *args, **kwargs):
@@ -424,7 +419,7 @@ class EnquiryDeleteView(DeleteView):
     def post(self, request, **kwargs):
         enquiry = get_object_or_404(models.Enquiry, pk=kwargs["pk"])
         enquiry.delete()
-        return redirect("enquiry-list")
+        return redirect("index")
 
 
 class EnquiryCompanySearchView(TemplateView):
@@ -525,8 +520,7 @@ class ImportEnquiriesView(TemplateView):
         file_obj = request.FILES.get(enquiries_key)
         if not file_obj:
             messages.error(
-                self.request,
-                "No file was selected. Choose a file to upload.",
+                self.request, "No file was selected. Choose a file to upload.",
             )
             return HttpResponseRedirect(reverse("import-enquiries"))
 

--- a/app/urls.py
+++ b/app/urls.py
@@ -25,7 +25,6 @@ urlpatterns = [
     path("", views.EnquiryListView.as_view(), name="index"),
     path("admin/", admin.site.urls),
     path("enquiry/", views.EnquiryCreateView.as_view(), name="enquiry-create"),
-    path("enquiries/", views.EnquiryListView.as_view(), name="enquiry-list"),
     path(
         "enquiries/template/", views.ImportTemplateDownloadView.as_view(), name="import-template",
     ),

--- a/cypress/e2e_tests/specs/delete.test.js
+++ b/cypress/e2e_tests/specs/delete.test.js
@@ -3,7 +3,7 @@ const { results, details } = require('../selectors')
 
 describe('Delete', () => {
   before(() => {
-    cy.reseed('/enquiries/')
+    cy.reseed('/')
   })
 
   beforeEach(() => {

--- a/cypress/e2e_tests/specs/edit.test.js
+++ b/cypress/e2e_tests/specs/edit.test.js
@@ -9,7 +9,7 @@ const { results, details } = require('../selectors')
 
 describe('Edit', () => {
   before(() => {
-    cy.reseed('/enquiries/')
+    cy.reseed('/')
   })
 
   beforeEach(() => {
@@ -24,7 +24,7 @@ describe('Edit', () => {
         .find('a')
         .eq(0)
         .should('have.text', 'Back')
-        .and('have.attr', 'href', '/enquiries/')
+        .and('have.attr', 'href', '/')
         .parents()
         .find('a')
         .should('contain', 'Edit details')

--- a/cypress/e2e_tests/specs/filter.test.js
+++ b/cypress/e2e_tests/specs/filter.test.js
@@ -204,7 +204,7 @@ const testPagination = ({ filters, owner, totalPages, pages }) =>
 
 describe('Filters', () => {
   before(() => {
-    cy.reseed('/enquiries/')
+    cy.reseed('/')
   })
   beforeEach(() => Cypress.Cookies.preserveOnce('sessionid'))
 

--- a/cypress/e2e_tests/specs/list-view.test.js
+++ b/cypress/e2e_tests/specs/list-view.test.js
@@ -12,7 +12,7 @@ const shorterEnquiryText =
 describe('View list of enquiries', () => {
   context('Enquiry text', () => {
     beforeEach(() => {
-      cy.reseed('/enquiries/')
+      cy.reseed('/')
       Cypress.Cookies.preserveOnce('sessionid')
     })
     it('Should truncate enquiry text if more than 250 characters but keep final word intact', () => {

--- a/cypress/e2e_tests/specs/sort.test.js
+++ b/cypress/e2e_tests/specs/sort.test.js
@@ -18,7 +18,7 @@ const testDateSort = (searchString, fieldIndex, ascending) => {
 
 describe('Sorting enquiries list view', () => {
   before(() => {
-    cy.reseed('/enquiries')
+    cy.reseed('/')
   })
   beforeEach(() => Cypress.Cookies.preserveOnce('sessionid'))
 

--- a/cypress/e2e_tests/specs/submit.test.js
+++ b/cypress/e2e_tests/specs/submit.test.js
@@ -24,7 +24,7 @@ const getDetail = field =>
 describe('Submit', () => {
 
   beforeEach(() => {
-    cy.reseed('/enquiries/')
+    cy.reseed('/')
     Cypress.Cookies.preserveOnce('sessionid')
   })
 


### PR DESCRIPTION
## Description of change

There are currently two routes for the homepage: `/`  and `/enquiries`. As having `enquiries` is unnecessary, this PR removes this URL and replaces use of it with the use of the index URL.

I will make sure users are made aware of the change in case they have any bookmarks saved to particular filters on the homepage.

## Test instructions

The homepage url should just be `localhost:8001`, everything else should work as expected.