### PR TITLE
Make sure daily cron task only runs once a day

### DIFF
--- a/app/enquiries/celery.py
+++ b/app/enquiries/celery.py
@@ -29,7 +29,9 @@ app.conf.beat_schedule = {
     },
     "update-stage-stale-enquiries": {
         "task": "update_stage_stale_enquiries",
-        "schedule": crontab(day_of_month=f"*/{ENQUIRY_STATUS_UPDATE_INTERVAL_DAYS}")
+        "schedule": crontab(minute="0", hour="0",
+                            day_of_month=f"*/{ENQUIRY_STATUS_UPDATE_INTERVAL_DAYS}"
+                            )
     }
 } if ENQUIRY_STATUS_SHOULD_UPDATE else {
     "refresh-datahub-metadata": {


### PR DESCRIPTION
## Description of change
Updates the `update-stage-stale-enquiries` task to make sure it does not run each minute!

## Test instructions
Run the app with `ENQUIRY_STATUS_SHOULD_UPDATE=1` - even with this, the `update-stage-stale-enquiries` task should not run (unless you are running this at midnicght)