### PR TITLE
Add a Circle CI workflow for docs deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
       - persist_to_workspace:
           root: doc/build
           paths: html
+      - store_artifacts:
+          path: doc/build/html
+          destination: docs
   docs-deploy:
     docker:
       - image: node:8.10.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
 version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.2
+  dotenv: anilanar/dotenv@volatile
 jobs:
-  build:
+  test:
     machine:
       docker_layer_caching: true
     working_directory: ~/emt
@@ -40,3 +41,60 @@ jobs:
           file: coverage.xml
       - store_artifacts:
           path: cypress/screenshots
+  docs-build:
+    docker:
+      - image: python:3.8
+    steps:
+      - checkout
+      - dotenv/source:
+          path: sample_env
+      - run:
+          name: Install docs dependencies
+          command: |
+            pwd
+            ls -lta
+            cd doc/
+            ./bootstrap.sh
+      - run:
+          name: Build docs
+          command: cd doc/ && make html
+      - persist_to_workspace:
+          root: doc/build
+          paths: html
+  docs-deploy:
+    docker:
+      - image: node:8.10.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: doc/build
+      - run:
+          name: Disable jekyll builds
+          command: touch doc/build/html/.nojekyll
+      - run:
+          name: Install dependencies
+          command: |
+            npm install -g --silent gh-pages@2.0.1
+            git config user.email "ci-build@digital.trade.gov.uk"
+            git config user.name "ci-build"
+      - add_ssh_keys:
+          fingerprints:
+            - "95:62:d7:98:68:5b:90:84:87:5b:0f:e9:f6:c6:82:a6"
+      - run:
+          name: Deploy docs to gh-pages branch
+          command: gh-pages --dotfiles --message "[skip ci] Updates" --dist doc/build/html
+
+workflows:
+  version: 1
+  emt-workflow:
+    jobs:
+      - test
+      - docs-build
+      - docs-deploy:
+          requires:
+            - test
+            - docs-build
+          filters:
+            branches:
+              only: master
+

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,12 @@
 Enquiry Management Tool
 =======================
 
+.. note::
+
+    You can read the compiled documentation
+    `here <https://uktrade.github.io/enquiry-mgmt-tool>`_.
+    You should also read the |em-playbook|_ in the |dit-docs|_.
+
 The *Enquiry Management Tool* is a web application designed for the
 needs of the |ist|_ based in Belfast, to simplify the management of *investment
 enquiries*. It allows for:
@@ -295,13 +301,35 @@ You can then compile the HTML with:
 
 The compiled HTML will then be in ``doc/build``.
 
+Hosting the compiled documentation
+""""""""""""""""""""""""""""""""""
+
+There is a |ci-workflow|_ defined in |file-ci-config|_ which compiles
+and deploys the documentation to the |gh-pages|_ branch of the |repository|_
+when code is pushed to the ``master`` branch, which is after every PR merge.
+The deployed documentation will then be available at
+`<https://uktrade.github.io/enquiry-mgmt-tool>`_.
+
+
 .. rst_prolog (do not remove this comment, it is used in doc/source/config.py)
+
+.. |repository| replace:: repository
+.. _repository: https://github.com/uktrade/enquiry-mgmt-tool/
+
+.. |gh-pages| replace:: ``gh-pages``
+.. _gh-pages: https://github.com/uktrade/enquiry-mgmt-tool/tree/gh-pages
 
 .. |data-hub| replace:: DataHub
 .. _data-hub: https://readme.trade.gov.uk/docs/playbooks/datahub.html
 
 .. |great| replace:: GREAT
 .. _great: https://readme.trade.gov.uk/docs/playbooks/great.gov.uk-website.html
+
+.. |dit-docs| replace:: DIT Software Development Manual
+.. _dit-docs: https://readme.trade.gov.uk
+
+.. |em-playbook| replace:: Enquiry Management playbook
+.. _em-playbook: https://readme.trade.gov.uk/docs/playbooks/enquiry-management.html
 
 .. |investment-form| replace:: Contact the investment team form
 .. _investment-form: https://www.great.gov.uk/international/invest/contact/
@@ -332,6 +360,12 @@ The compiled HTML will then be in ``doc/build``.
 
 .. |oauth| replace:: OAuth 2.0
 .. _oauth: https://oauth.net/2/
+
+.. |circle-ci| replace:: CircleCI
+.. _circle-ci: https://app.circleci.com/pipelines/github/uktrade/enquiry-mgmt-tool
+
+.. |ci-workflow| replace:: |circle-ci|_ workflow
+.. _ci-workflow: https://circleci.com/docs/2.0/workflows-overview/
 
 .. |activity-stream| replace:: Activity Stream
 .. _activity-stream: https://readme.trade.gov.uk/docs/playbooks/activity-stream/index.html
@@ -410,3 +444,6 @@ The compiled HTML will then be in ``doc/build``.
 
 .. |file-sass| replace:: ``sass/``
 .. _file-sass: https://github.com/uktrade/enquiry-mgmt-tool/blob/master/app/sass/
+
+.. |file-ci-config| replace:: ``.circleci/config.yml``
+.. _file-ci-config: https://github.com/uktrade/enquiry-mgmt-tool/blob/master/.circleci/config.yml

--- a/doc/bootstrap.sh
+++ b/doc/bootstrap.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Merge project requirements with documentation requirements,
 # exclude the psycopg2 package which is replaced with psycopg2-binary in
 # documentation requirements.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -43,7 +43,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "celery.contrib.sphinx",
-    "djcommanddoc",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Description of change

Adds a CircleCI job, which builds the documentation and then pushes the built content to the `gh-pages` branch. Which will make the compiled documentation accessible at https://uktrade.github.io/enquiry-mgmt-tool/.

## Test instructions

1. Merge a PR or push something to the `master` branch
2. You should see a `docs-deploy` job spawned on CircleCI
3. When the job is done, the up-to-date compiled documentation should be available at  https://uktrade.github.io/enquiry-mgmt-tool/