### PR TITLE
Enable auth for all views

### DIFF
--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -423,7 +423,7 @@ class EnquiryEditView(LoginRequiredMixin, UpdateView):
         return response
 
 
-class EnquiryDeleteView(DeleteView):
+class EnquiryDeleteView(LoginRequiredMixin, DeleteView):
     """
     Delete :class:`app.enquiries.models.Enquiry` view
     """
@@ -437,7 +437,7 @@ class EnquiryDeleteView(DeleteView):
         return redirect("index")
 
 
-class EnquiryCompanySearchView(TemplateView):
+class EnquiryCompanySearchView(LoginRequiredMixin, TemplateView):
     """|data-hub|_ company search view"""
 
     model = models.Enquiry
@@ -474,7 +474,7 @@ class EnquiryCompanySearchView(TemplateView):
         return render(request, self.template_name, context)
 
 
-class ImportEnquiriesView(TemplateView):
+class ImportEnquiriesView(LoginRequiredMixin, TemplateView):
     """
     Handles import of enquiries with a CSV file
     """
@@ -580,7 +580,7 @@ class ImportEnquiriesView(TemplateView):
         )
 
 
-class ImportTemplateDownloadView(View):
+class ImportTemplateDownloadView(LoginRequiredMixin, View):
     methods = ["get"]
     CONTENT_TYPE = settings.IMPORT_TEMPLATE_MIMETYPE
 

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -160,10 +160,6 @@ if FEATURE_FLAGS["ENFORCE_STAFF_SSO_ON"]:
 
     LOGIN_URL = reverse_lazy("authbroker_client:login")
     LOGIN_REDIRECT_URL = reverse_lazy("index")
-    MIDDLEWARE.append(
-        # middleware to check auth for all views, alternatively use login_required decorator
-        "authbroker_client.middleware.ProtectAllViewsMiddleware",
-    )
 else:
     LOGIN_URL = "/admin/login/"
 # Database

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -160,10 +160,10 @@ if FEATURE_FLAGS["ENFORCE_STAFF_SSO_ON"]:
 
     LOGIN_URL = reverse_lazy("authbroker_client:login")
     LOGIN_REDIRECT_URL = reverse_lazy("index")
-    # MIDDLEWARE.append(
-    #     # middleware to check auth for all views, alternatively use login_required decorator
-    #     "authbroker_client.middleware.ProtectAllViewsMiddleware",
-    # )
+    MIDDLEWARE.append(
+        # middleware to check auth for all views, alternatively use login_required decorator
+        "authbroker_client.middleware.ProtectAllViewsMiddleware",
+    )
 else:
     LOGIN_URL = "/admin/login/"
 # Database


### PR DESCRIPTION
## Description of change

The intent of this PR is to ensure that all urls require authentication when trying to access them. Given we use django_staff_sso, this could be done by adding a rule to authbroker config.

## Test instructions

Once deployed to staging or an environment that has SSO integration, try to navigate to the following URL:

https://enquiry-mgmt.trade.gov.uk/enquiries/1/company-search

The expected behaviour is that if you are not logged in it should redirect you to the auth page, otherwise it should return the company search page.