### PR TITLE
Increase default gunicorn timeout to 5 minutes

### DIFF
--- a/app/gunicorn.py
+++ b/app/gunicorn.py
@@ -4,6 +4,7 @@ import os
 # Access log settings
 
 accesslog = os.environ.get("GUNICORN_ACCESSLOG", "-")
+timeout = 60 * 5
 access_log_format = os.environ.get(
     "GUNICORN_ACCESS_LOG_FORMAT",
     '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s %({X-Forwarded-For}i)s',


### PR DESCRIPTION
## Description of change

Increase the default 30s gUnicorn timeout to 5 minutes as a temporary fix to the issues with the _Download all_ functionality.
