### PR TITLE
Fixes related to handling of second qualification forms

### DIFF
--- a/app/enquiries/common/as_utils.py
+++ b/app/enquiries/common/as_utils.py
@@ -361,7 +361,7 @@ def get_new_second_qualification_forms(last_datetime=None, max_size=100):
     secret_key = settings.ACTIVITY_STREAM_KEY
     url = settings.ACTIVITY_STREAM_SEARCH_URL
     search_filter = [
-        {"range": {"object.published": {"gte": last_datetime}}}
+        {"range": {"object.published": {"gte": last_datetime.isoformat()}}}
     ] if last_datetime else []
     search_filter += [
         {

--- a/app/enquiries/tests/test_adobe_integration.py
+++ b/app/enquiries/tests/test_adobe_integration.py
@@ -182,3 +182,8 @@ class TestAdobeCampaign(TestCase):
 
         last_action_date = EnquiryActionLog.get_last_action_date(action)
         self.assertEqual(last_action_date.enquiry.id, self.enquiry.id)
+
+    @freeze_time()
+    def test_process_enquiry_update_bad_id(self):
+        log = campaign.process_enquiry_update(None)
+        assert log is None

--- a/app/enquiries/tests/test_adobe_integration.py
+++ b/app/enquiries/tests/test_adobe_integration.py
@@ -182,8 +182,3 @@ class TestAdobeCampaign(TestCase):
 
         last_action_date = EnquiryActionLog.get_last_action_date(action)
         self.assertEqual(last_action_date.enquiry.id, self.enquiry.id)
-
-    @freeze_time()
-    def test_process_enquiry_update_bad_id(self):
-        log = campaign.process_enquiry_update(None)
-        assert log is None


### PR DESCRIPTION
## Description of change

use an isoformated date for as search. 
check if emt was provided in second qual form. 
use just date when filtering for second qual to catch discrepancies between log date and 2nd qual submission