### PR TITLE
Enquiry ID filter

### DIFF
--- a/app/enquiries/templates/partials/enquiry_filters.html
+++ b/app/enquiries/templates/partials/enquiry_filters.html
@@ -62,6 +62,12 @@
     </label>
     <input class="govuk-input" id="project_code__icontains" name="project_code__icontains" type="search" value="{{query_params.project_code__icontains}}">
   </div>
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="project_code__icontains">
+      Enquiry ID
+    </label>
+    <input class="govuk-input" id="emt_id" name="id" type="search" value="{{query_params.id}}">
+  </div>
   <button id="btn_submit" class="govuk-button govuk-!-margin-right-1" data-module="govuk-button" accesskey="s">
     Apply filters
   </button>

--- a/app/enquiries/templates/partials/enquiry_filters.html
+++ b/app/enquiries/templates/partials/enquiry_filters.html
@@ -63,7 +63,7 @@
     <input class="govuk-input" id="project_code__icontains" name="project_code__icontains" type="search" value="{{query_params.project_code__icontains}}">
   </div>
   <div class="govuk-form-group">
-    <label class="govuk-label" for="project_code__icontains">
+    <label class="govuk-label" for="emt_id">
       Enquiry ID
     </label>
     <input class="govuk-input" id="emt_id" name="id" type="search" value="{{query_params.id}}">

--- a/app/enquiries/tests/test_filters.py
+++ b/app/enquiries/tests/test_filters.py
@@ -82,3 +82,6 @@ class EnquiryViewFiltersTestCase(test_utils.BaseEnquiryTestCase):
         self.assertIsNotNone(
             soup.find(id="project_code__icontains"), msg="should render project_code control"
         )
+        self.assertIsNotNone(
+            soup.find(id="emt_id"), msg="should render emt_id control"
+        )

--- a/app/enquiries/views.py
+++ b/app/enquiries/views.py
@@ -207,6 +207,7 @@ class EnquiryFilter(filters.FilterSet):
     """
     Enquiry search filters
     """
+    id = filters.NumberFilter(field_name="id", method="filter_id")
     owner__id = filters.CharFilter(field_name="owner__id", method="filter_owner_id")
     received__lt = filters.DateFilter(field_name="receive", method="filter_received_lt")
     received__gt = filters.DateFilter(field_name="receive", method="filter_received_gt")
@@ -214,6 +215,9 @@ class EnquiryFilter(filters.FilterSet):
         field_name="enquiry_stage", lookup_expr="in", method="filter_enquiry_stage"
     )
     enquirer__email = filters.CharFilter(field_name="enquirer__email", lookup_expr="icontains")
+
+    def filter_id(self, queryset, name, value):
+        return queryset.filter(id=value)
 
     def filter_enquiry_stage(self, queryset, name, value):
         values = self.request.GET.getlist(name)

--- a/cypress/e2e_tests/specs/filter.test.js
+++ b/cypress/e2e_tests/specs/filter.test.js
@@ -80,8 +80,8 @@ const submitFilters = () =>
   cy.contains('Apply filters')
     .as('submit')
     .click()
-  
-const setOwner = id => 
+
+const setOwner = id =>
   cy.get('label').contains('Owner').next()
     .select(id === UNASSIGNED ? 'Unassigned' : USERS[id])
 
@@ -302,7 +302,7 @@ describe('Filters', () => {
     expectedTotal: 0,
     assertItem: () => {},
   })
-  
+
   testFilters({
     filters: {
       [FILTERS.nonResponsive]: true,
@@ -321,7 +321,7 @@ describe('Filters', () => {
       cy.wrap($li).contains(/(^\s*Dominique Fernandez\s*$)/)
     },
   })
-  
+
   testFilters({
     filters: {
       [FILTERS.nonApplicable]: true,
@@ -359,7 +359,7 @@ describe('Filters', () => {
       cy.wrap($li).contains(/(^\s*Unassigned\s*$)/)
     },
   })
-  
+
   testFilters({
     filters: {
       [FILTERS.added]: true,
@@ -386,7 +386,7 @@ describe('Filters', () => {
     expectedTotal: 0,
     assertItem: () => {},
   })
-  
+
   testFilters({
     filters: {
       [FILTERS.sent]: true,
@@ -417,7 +417,7 @@ describe('Filters', () => {
       cy.wrap($li).contains(/(^\s*Unassigned\s*$)/)
     },
   })
-  
+
   testFilters({
     filters: {
       [FILTERS.postProgressing]: true,
@@ -447,7 +447,7 @@ describe('Filters', () => {
       cy.wrap($li).contains(/(^\s*Unassigned\s*$)/)
     },
   })
-  
+
   testFilters({
     filters: {},
     owner: UNASSIGNED,
@@ -483,7 +483,7 @@ describe('Filters', () => {
       cy.wrap($li).contains(/(^\s*Kaylee Richards\s*$)/)
     },
   })
-  
+
   testFilters({
     filters: {},
     owner: 2,
@@ -501,7 +501,7 @@ describe('Filters', () => {
       cy.wrap($li).contains(/(^\s*Sam Koenen\s*$)/)
     },
   })
-  
+
   testFilters({
     filters: {},
     owner: 3,
@@ -519,7 +519,7 @@ describe('Filters', () => {
       cy.wrap($li).contains(/(^\s*Julia Mieville\s*$)/)
     },
   })
-  
+
   testFilters({
     filters: {},
     owner: 4,
@@ -550,7 +550,7 @@ describe('Filters', () => {
     owner: 4,
     expectedTotal: 0,
   })
-  
+
   testFilters({
     filters: {},
     owner: 5,
@@ -568,7 +568,7 @@ describe('Filters', () => {
       cy.wrap($li).contains(/(^\s*Aiden Collet\s*$)/)
     },
   })
-  
+
   testFilters({
     filters: {
       'Received before': '2018-01-01',
@@ -583,7 +583,7 @@ describe('Filters', () => {
           expect(new Date($el.text())).to.be.below(new Date('2018-01-01'))
         ),
   })
-  
+
   testFilters({
     filters: {
       'Received after': '2019-01-01',
@@ -598,7 +598,7 @@ describe('Filters', () => {
           expect(new Date($el.text())).to.be.above(new Date('2001-01-01'))
         ),
   })
-  
+
   testFilters({
     filters: {
       'Received before': '2018-01-01',
@@ -616,7 +616,7 @@ describe('Filters', () => {
           )
         ),
   })
-  
+
   Object.entries({
     matchbox: [15, 3],
     company: [10, 2],
@@ -644,7 +644,7 @@ describe('Filters', () => {
       },
     })
   })
-  
+
   Object.entries({
     'evelyn.wang@example.com': 26,
     'jeff.bezos@washingtonpost.com': 12,
@@ -667,7 +667,7 @@ describe('Filters', () => {
       },
     })
   )
-  
+
   testFilters({
     filters: {
       'Company added to Data Hub before': '2020-02-04',
@@ -684,14 +684,14 @@ describe('Filters', () => {
       })
     },
   })
-  
+
   testFilters({
     filters: {
       'Company added to Data Hub before': '2020-02-03',
     },
     expectedTotal: 0,
   })
-  
+
   testFilters({
     filters: {
       'Company added to Data Hub after': '2020-02-02',
@@ -707,14 +707,14 @@ describe('Filters', () => {
       })
     },
   })
-  
+
   testFilters({
     filters: {
       'Company added to Data Hub after': '2020-02-03',
     },
     expectedTotal: 0,
   })
-  
+
   it("Should display results for all owners when the '---' option is selected", () => {
     setOwner(1),
     submitFilters()
@@ -728,5 +728,15 @@ describe('Filters', () => {
       'Data Hub project code': 'DHP-00000002',
     },
     expectedTotal: 1,
+  })
+
+  testFilters({
+    filters: {
+      'Enquiry ID': '18',
+    },
+    expectedTotal: 1,
+    assertItem: ($li) => {
+      cy.wrap($li).contains(/^ABC Electronics$/)
+    },
   })
 })

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
 python manage.py migrate
-# sh setup-test-fixtures.sh
+sh setup-test-fixtures.sh
 # -a to append coverage
 exec coverage run -a manage.py runserver 0.0.0.0:8001 --noreload

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
 python manage.py migrate
-sh setup-test-fixtures.sh
+# sh setup-test-fixtures.sh
 # -a to append coverage
 exec coverage run -a manage.py runserver 0.0.0.0:8001 --noreload


### PR DESCRIPTION
Add an enquiry id filter. This helps users locate an enquiry based on
the id and is useful for locating submissions of second qualification
forms.

## Description of change

Adds a new filter search field, and subsequent filter definition

## Test instructions

In the enquiries screen a new field should show at the bottom of the filter list. 