### PR TITLE
Submit project name as name

### DIFF
--- a/app/enquiries/common/datahub_utils.py
+++ b/app/enquiries/common/datahub_utils.py
@@ -442,7 +442,7 @@ def prepare_dh_payload(
     )
 
     payload = dict(
-        name=enquiry.company_name,
+        name=enquiry.project_name,
         investor_company=company_id,
         description=enquiry.project_description,
         anonymous_description=enquiry.anonymised_project_description,

--- a/app/enquiries/templatetags/enquiries_extras.py
+++ b/app/enquiries/templatetags/enquiries_extras.py
@@ -71,6 +71,7 @@ def can_be_submitted(enquiry):
         not enquiry.date_added_to_datahub
         and enquiry.enquiry_stage != ref_data.EnquiryStage.ADDED_TO_DATAHUB
         and enquiry.datahub_project_status == ref_data.DatahubProjectStatus.DEFAULT
+        and enquiry.project_name
     )
 
 


### PR DESCRIPTION
## Description of change

This fixes an issue where investment project has been created using company name as name, instead of project name. 

## Test instructions

A test to check that project name is being used has been added.
