### PR TITLE
Updated celery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==19.3.0
 backcall==0.1.0
 beautifulsoup4==4.8.2
 cachecontrol-django==1.0.0
-celery[redis]==4.4
+celery[redis]==4.4.7
 certifi==2019.9.11
 cffi==1.13.2
 chardet==3.0.4


### PR DESCRIPTION
Updated `celery` to use updated `celery.contrib.sphinx` extension for sphinx documentation and fix currently broken doc build.