### PR TITLE
Upgrade celery to 5.2.2

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: ./web.sh
-celery: celery worker -A app -l info
-celerybeat: celery beat -A app -l info
+celery: celery -A app worker -l info
+celerybeat: celery -A app beat -l info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - db
       - redis
     entrypoint: dockerize -wait tcp://db:5432 -wait tcp://redis:6379 -timeout 5m
-    command: celery worker -A app -l info -Q celery -B
+    command: celery -A app worker -l info -Q celery -B
 
   db:
     image: postgres

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==19.3.0
 backcall==0.1.0
 beautifulsoup4==4.8.2
 cachecontrol-django==1.0.0
-celery[redis]==4.4.7
+celery[redis]==5.2.2
 certifi==2019.9.11
 cffi==1.13.2
 chardet==3.0.4


### PR DESCRIPTION
## Description of change

This PR upgrades celery to version 5.2.2 as previous versions contain a [security vulnerability](https://github.com/uktrade/enquiry-mgmt-tool/security/dependabot/requirements.txt/celery/open). 

## Test instructions

No visible changes.