### PR TITLE
Update company id format in contact request

### DIFF
--- a/app/enquiries/common/datahub_utils.py
+++ b/app/enquiries/common/datahub_utils.py
@@ -292,7 +292,7 @@ def dh_contact_create(request, access_token, enquirer, company_id, primary=False
         "first_name": enquirer.first_name,
         "last_name": enquirer.last_name,
         "job_title": enquirer.job_title,
-        "company": company_id,
+        "company": {"id": company_id},
         "primary": primary,
         "telephone_countrycode": enquirer.phone_country_code,
         "telephone_number": enquirer.phone,

--- a/app/enquiries/common/datahub_utils.py
+++ b/app/enquiries/common/datahub_utils.py
@@ -227,7 +227,7 @@ def dh_get_company_contact_list(request, access_token, company_id):
             "last_name": contact["last_name"],
             "job_title": contact["job_title"],
             "email": contact["email"],
-            "phone": contact["telephone_number"],
+            "phone": contact["full_telephone_number"],
         }
         for contact in response.json()["results"]
     ]
@@ -295,7 +295,7 @@ def dh_contact_create(request, access_token, enquirer, company_id, primary=False
         "company": {"id": company_id},
         "primary": primary,
         "telephone_countrycode": enquirer.phone_country_code,
-        "telephone_number": enquirer.phone,
+        "full_telephone_number": enquirer.phone,
         "email": enquirer.email,
         "address_same_as_company": True,
     }

--- a/app/enquiries/tests/test_dh_integration.py
+++ b/app/enquiries/tests/test_dh_integration.py
@@ -54,7 +54,7 @@ def contact_search_response():
                     "first_name": "Datahub",
                     "last_name": "User",
                     "job_title": "CEO",
-                    "telephone_number": "123456789",
+                    "full_telephone_number": "123456789",
                     "email": "user@example.com",
                 }
             ]

--- a/app/enquiries/tests/test_dh_utils.py
+++ b/app/enquiries/tests/test_dh_utils.py
@@ -30,7 +30,7 @@ def contact_search_response():
                     "first_name": MATCHING_CONTACT_DETAILS["first_name"],
                     "last_name": MATCHING_CONTACT_DETAILS["last_name"],
                     "job_title": "CEO",
-                    "telephone_number": "123456789",
+                    "full_telephone_number": "123456789",
                     "email": MATCHING_CONTACT_DETAILS["email"],
                 }
             ]
@@ -75,8 +75,9 @@ class DataHubUtilsTests(TestCase):
                 "last_name": contact["last_name"],
                 "job_title": contact["job_title"],
                 "email": contact["email"],
-                "phone": contact["telephone_number"],
-            } for contact in contact_search_response()["success"]["results"]
+                "phone": contact["full_telephone_number"],
+            }
+            for contact in contact_search_response()["success"]["results"]
         ]
         self.access_token = "mock_token"
         self.dh_company_id = "1234-5678"


### PR DESCRIPTION
## Description of change

This PR fixes a live issue in which users are unable to submit investment enquiries to Data Hub.

The issue was caused by changes to the contact model/serializer in the Data Hub API, which weren't reflected in the requests made by the enquiry management tool, namely:
- When posting a new contact to the DH API, the company id now needs to be in the format `{"company": "id": 123}}
- The `telephone_number` field is now `full_telephone_number`



## Test instructions

This branch has been deployed to our dev environment and is working successfully.