### PR TITLE
CPS-378: catch http errors correctly

### DIFF
--- a/app/enquiries/common/consent.py
+++ b/app/enquiries/common/consent.py
@@ -42,11 +42,13 @@ def check_consent(key):
     url = f"{settings.CONSENT_SERVICE_BASE_URL}{CONSENT_SERVICE_PATH_PERSON}{key}/"
     try:
         response = request(url=url, method="GET")
+        response.raise_for_status()
         return bool(len(response.json()["consents"]))
     except HTTPError as e:
-        if e.response and e.response.status_code == status.HTTP_404_NOT_FOUND:
+        if e.response.status_code == status.HTTP_404_NOT_FOUND:
             return False
-    return False
+        else:
+            raise
 
 
 def set_consent(key, value=True):

--- a/app/enquiries/tests/test_common_consent.py
+++ b/app/enquiries/tests/test_common_consent.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from requests import HTTPError
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
@@ -7,6 +8,13 @@ from app.enquiries.common import consent
 
 
 class TestConsent:
+    def set_valid_settings(self, settings):
+        settings.FEATURE_FLAGS["ENFORCE_CONSENT_SERVICE"] = True
+        settings.CONSENT_SERVICE_HAWK_ID = "id"
+        settings.CONSENT_SERVICE_HAWK_KEY = "key"
+        settings.CONSENT_SERVICE_BASE_URL = "http://local.host"
+        settings.CONSENT_SERVICE_VERIFY_RESPONSE = False
+
     def test_is_disabled(self):
         assert consent.check_consent("key") is None
         assert consent.set_consent("key") is None
@@ -18,10 +26,7 @@ class TestConsent:
 
     @mock.patch('app.enquiries.common.consent.APIClient')
     def test_valid_configuration(self, mock_client, settings):
-        settings.FEATURE_FLAGS["ENFORCE_CONSENT_SERVICE"] = True
-        settings.CONSENT_SERVICE_HAWK_ID = "id"
-        settings.CONSENT_SERVICE_HAWK_KEY = "key"
-        settings.CONSENT_SERVICE_BASE_URL = "http://local.host"
+        self.set_valid_settings(settings)
         assert mock_client.call_count == 0
         consent.check_consent("key")
         assert mock_client.call_count == 1
@@ -36,15 +41,26 @@ class TestConsent:
     ])
     def test_check_consent(self, requests_mock, settings, params):
         key, path, consents, result = params
-        settings.FEATURE_FLAGS["ENFORCE_CONSENT_SERVICE"] = True
-        settings.CONSENT_SERVICE_HAWK_ID = "id"
-        settings.CONSENT_SERVICE_HAWK_KEY = "key"
-        settings.CONSENT_SERVICE_BASE_URL = "http://local.host"
-        settings.CONSENT_SERVICE_VERIFY_RESPONSE = False
+        self.set_valid_settings(settings)
 
         url = f"{settings.CONSENT_SERVICE_BASE_URL}/api/v1/person/{path}/"
         requests_mock.get(url=url, json={"consents": consents})
         assert consent.check_consent(key) is result
+
+    def test_check_consent_when_404(self, requests_mock, settings):
+        self.set_valid_settings(settings)
+
+        url = f"{settings.CONSENT_SERVICE_BASE_URL}/api/v1/person/key/"
+        requests_mock.get(url=url, status_code=404)
+        assert consent.check_consent('key') is False
+
+    def test_check_consent_when_500(self, requests_mock, settings):
+        self.set_valid_settings(settings)
+
+        url = f"{settings.CONSENT_SERVICE_BASE_URL}/api/v1/person/key/"
+        requests_mock.get(url=url, status_code=500)
+        with pytest.raises(HTTPError):
+            consent.check_consent('key')
 
     @mock.patch('app.enquiries.common.consent.request')
     @pytest.mark.parametrize("params", [


### PR DESCRIPTION
## Description of change

The consent service was returning 404s for missing consent data, which were not being caught correctly and causing the page to return a 500. 
It is possible for people not to exist on the consent service if the enquiries were added manually (rather than through the Activity Stream) so we want to handle 404s and return False. Any other HTTPErrors, such as 500, should be raised. 

The code coverage tool is alerting that this code is not covered by
tests, but we have written unit tests to cover it. The e2e specs do not
currently have the setting `FEATURE_ENFORCE_CONSENT_SERVICE` on, so no
consent integration has ever been tested, and it's outside of the scope
of this bug fix.

## Test instructions

App should work as normal.