### PR TITLE
CPS-378: handle consent api responses when they are a list

### DIFF
--- a/app/enquiries/common/consent.py
+++ b/app/enquiries/common/consent.py
@@ -43,7 +43,9 @@ def check_consent(key):
     try:
         response = request(url=url, method="GET")
         response.raise_for_status()
-        return bool(len(response.json()["consents"]))
+        if 'consents' in response.json():
+            return bool(len(response.json()["consents"]))
+        return False
     except HTTPError as e:
         if e.response.status_code == status.HTTP_404_NOT_FOUND:
             return False


### PR DESCRIPTION
If a phone number for an enquirer is '.' the legal-basis-api returns a list of people,
rather than an object, which caused a key error when looking for the key
of `consents`.

## Test instructions

_What should I see? (If visible changes)_