### PR TITLE
Replace always_hash_content=False with dummy data.

### DIFF
--- a/app/enquiries/common/datahub_utils.py
+++ b/app/enquiries/common/datahub_utils.py
@@ -100,8 +100,10 @@ def fetch_metadata(name):
         auth=HawkAuth(
             id=settings.DATA_HUB_HAWK_ID,
             key=settings.DATA_HUB_HAWK_KEY,
-            always_hash_content=False,
         ),
+        # Add dummy data to avoid error: MissingContent payload content and/or content_type cannot
+        # be empty when always_hash_content is True
+        data={""},
         timeout=10,
     )
     response.raise_for_status()


### PR DESCRIPTION
## Description of change

See ticket CPS-394

Add dummy data to fetch_metadata to fix error: MissingContent payload content and/or content_type cannot be empty when always_hash_content is True.

## Test instructions
An enquiry can be successfully submitted to Data Hub.

No visible changes.