### PR TITLE
Update redis to 6.2.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - 5432:5432
 
   redis:
-    image: redis:3.2
+    image: redis:6.2.6
 
   mock-sso:
     image: ukti/mock-sso


### PR DESCRIPTION
## Description of change

Redis has been upgraded to v6 in PaaS so I've updated it in the Dockerfile.