### PR TITLE
Add ALLOW_TEST_FIXTURE_SETUP to CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ jobs:
           # Chrome freezes when redirecting on the login page.
           # See: https://github.com/cypress-io/cypress/issues/3594
           command: docker-compose run cypress run --browser chrome
+          environment:
+            ALLOW_TEST_FIXTURE_SETUP: allow
       - run: docker-compose stop app
       - run: docker-compose run app coverage xml
       - codecov/upload:


### PR DESCRIPTION
## Description of change

The e2e tests have not been running properly because this required environment variable was missing. This has been added via the CircleCI settings but this hasn't completely worked so I'm adding it to the config as well.