### PR TITLE
Update flake8 hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8


### PR DESCRIPTION
## Description of change

The repository URL for `flake8` was out of date so I have changed it. I've also updated the `flake8` version in the hook to match the one defined in the requirements file.

## Test instructions

The `flake8` hook should work as normal. If it doesn't work you may need to run `make setup-flake8-hook` again.