### PR TITLE
Revert "Chore/dependencies 2023 06 19"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "govuk-frontend": "^4.6.0",
-        "sass": "^1.63.3"
+        "sass": "^1.62.1"
       },
       "devDependencies": {
         "cypress": "11.2.0",
@@ -1731,9 +1731,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.63.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.3.tgz",
-      "integrity": "sha512-ySdXN+DVpfwq49jG1+hmtDslYqpS7SkOR5GpF6o2bmb1RL/xS+wvPmegMvMywyfsmAV6p7TgwXYGrCZIFFbAHg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
+      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -3334,9 +3334,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.63.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.3.tgz",
-      "integrity": "sha512-ySdXN+DVpfwq49jG1+hmtDslYqpS7SkOR5GpF6o2bmb1RL/xS+wvPmegMvMywyfsmAV6p7TgwXYGrCZIFFbAHg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
+      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/uktrade/enquiry-mgmt-tool#readme",
   "dependencies": {
     "govuk-frontend": "^4.6.0",
-    "sass": "^1.63.3"
+    "sass": "^1.62.1"
   },
   "devDependencies": {
     "cypress": "11.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==23.1.0
 backcall==0.2.0
 beautifulsoup4==4.12.2
 cachecontrol-django==1.0.0
-celery[redis]==5.3.0
+celery[redis]==5.2.7
 certifi==2023.5.7
 cffi==1.15.1
 chardet==5.1.0
@@ -53,7 +53,7 @@ pycparser==2.21
 Pygments==2.15.1
 PyJWT==2.7.0
 pyparsing==3.0.9
-pytest==7.3.2
+pytest==7.3.1
 pytest-cov==4.1.0
 pytest-django==4.5.2
 pytest-freezegun==0.4.2
@@ -61,12 +61,12 @@ pytz==2023.3
 redis==4.5.5
 requests==2.31.0
 requests-hawk==1.2.1
-requests-mock==1.11.0
-sentry-sdk==1.25.1
+requests-mock==1.10.0
+sentry-sdk==1.25.0
 six==1.16.0
 sqlparse==0.4.4
 traitlets==5.9.0
 uritemplate==4.1.1
-urllib3==2.0.3
+urllib3==1.26.15
 wcwidth==0.2.6
 whitenoise==6.4.0


### PR DESCRIPTION
Since the Dependbot PR was merged the EMT celery instances constantly crash, meaning that no new enquiries are coming through.