### PR TITLE
Restore Dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     - dependency-name: sphinx
       versions:
       - ">= 5.3.0"
+    - dependency-name: celery[redis]
+      versions:
+      - ">= 5.2.7"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "govuk-frontend": "^4.6.0",
-        "sass": "^1.62.1"
+        "sass": "^1.63.6"
       },
       "devDependencies": {
         "cypress": "11.2.0",
@@ -1731,9 +1731,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
-      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
+      "version": "1.63.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
+      "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -3334,9 +3334,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
-      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
+      "version": "1.63.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
+      "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/uktrade/enquiry-mgmt-tool#readme",
   "dependencies": {
     "govuk-frontend": "^4.6.0",
-    "sass": "^1.62.1"
+    "sass": "^1.63.6"
   },
   "devDependencies": {
     "cypress": "11.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ py==1.11.0
 pycparser==2.21
 Pygments==2.15.1
 PyJWT==2.7.0
-pyparsing==3.0.9
+pyparsing==3.1.0
 pytest==7.3.1
 pytest-cov==4.1.0
 pytest-django==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pycparser==2.21
 Pygments==2.15.1
 PyJWT==2.7.0
 pyparsing==3.1.0
-pytest==7.3.1
+pytest==7.3.2
 pytest-cov==4.1.0
 pytest-django==4.5.2
 pytest-freezegun==0.4.2
@@ -61,12 +61,12 @@ pytz==2023.3
 redis==4.5.5
 requests==2.31.0
 requests-hawk==1.2.1
-requests-mock==1.10.0
-sentry-sdk==1.25.0
+requests-mock==1.11.0
+sentry-sdk==1.25.1
 six==1.16.0
 sqlparse==0.4.4
 traitlets==5.9.0
 uritemplate==4.1.1
-urllib3==1.26.15
+urllib3==2.0.3
 wcwidth==0.2.6
 whitenoise==6.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,4 +69,4 @@ traitlets==5.9.0
 uritemplate==4.1.1
 urllib3==2.0.3
 wcwidth==0.2.6
-whitenoise==6.4.0
+whitenoise==6.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-cache-memoize==0.1.10
 django-environ==0.10.0
 django-extensions==3.2.3
 django-filter==23.2
-django-redis==5.2.0
+django-redis==5.3.0
 django-rest-knox==4.2.0
 django-staff-sso-client==4.2.0
 djangorestframework==3.14.0


### PR DESCRIPTION
## Description of change

This week's Dependabot PR had to be rolled back due to an issue with Celery. This PR restores all the upgrades that weren't related to Celery and also includes the other open Dependabot PRs.