### PR TITLE
Upgrade to Django 4.2

### DIFF
--- a/app/enquiries/templates/base.html
+++ b/app/enquiries/templates/base.html
@@ -38,5 +38,5 @@
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 
   </script>
-
+  <script type="text/javascript" src="{% static 'jquery/jquery.min.js' %}"></script>
   <a href="#main-content" class="govuk-skip-link">Skip to main content</a>

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -172,6 +172,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators
 
@@ -205,6 +207,7 @@ APP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 STATIC_ROOT = os.path.join(APP_ROOT, 'enquiries', 'static')
 STATICFILES_DIRS = [
     ('govuk-frontend', 'node_modules/govuk-frontend/dist/govuk'),
+    ('jquery', 'node_modules/jquery/dist/'),
 ]
 
 # This setting alone will NOT enable the "Test Fixture API" facility -

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "govuk-frontend": "^5.3.0",
+        "jquery": "^3.7.1",
         "sass": "^1.75.0"
       },
       "devDependencies": {
@@ -1237,6 +1238,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
@@ -2997,6 +3003,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
+    },
+    "jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "jsbn": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/uktrade/enquiry-mgmt-tool#readme",
   "dependencies": {
     "govuk-frontend": "^5.3.0",
+    "jquery": "^3.7.1",
     "sass": "^1.75.0"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ coreschema==0.0.4
 coverage==7.4.4
 cryptography==42.0.5
 decorator==5.1.1
-Django==3.2.25
-django-autocomplete-light==3.5.0
+Django==4.2.10
+django-autocomplete-light==3.11.0
 django-cache-memoize==0.2.0
 django-environ==0.11.2
 django-extensions==3.2.3


### PR DESCRIPTION
## Description of change

Upgrade to Django 4.2.
Includes required upgrade of django-autocomplete-light which has removed jQuery from its install, so jquery has been added to package.json now.
Fixed warning from 3.2 by defining DEFAULT_AUTO_FIELD

## Test instructions

_What should I see? (If visible changes)_