### PR TITLE
Bump Django to 4.2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-autocomplete-light==3.11.0
 django-cache-memoize==0.2.0
 django-environ==0.11.2
 django-extensions==3.2.3
-django-filter==23.5
+django-filter==24.2
 django-redis==5.4.0
 django-rest-knox==4.2.0
 django-staff-sso-client==4.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-extensions==3.2.3
 django-filter==24.2
 django-redis==5.4.0
 django-rest-knox==4.2.0
-django-staff-sso-client==4.2.1
+django-staff-sso-client==4.2.2
 djangorestframework==3.15.1
 djangorestframework-csv==3.0.2
 drf-writable-nested==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ coreschema==0.0.4
 coverage==7.4.4
 cryptography==42.0.5
 decorator==5.1.1
-Django==4.2.10
+Django==4.2.11
 django-autocomplete-light==3.11.0
 django-cache-memoize==0.2.0
 django-environ==0.11.2


### PR DESCRIPTION
## Description of change

Bump Django to 4.2.11 to fix a vulnerability, and also merging a couple of previously blocked Dependabot PRs.