### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     ignore:
     - dependency-name: sphinx
       versions:
@@ -16,7 +16,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     ignore:
     - dependency-name: cypress
       versions:


### PR DESCRIPTION
## Description of change

We're going to be pausing Dependabot during the feature freeze so we don't want PRs being opened that we can't merge.