### PR TITLE
Log traceback when exception is raised 

### DIFF
--- a/app/enquiries/common/datahub_utils.py
+++ b/app/enquiries/common/datahub_utils.py
@@ -76,11 +76,11 @@ def dh_request(
             response = requests.post(url, headers=headers, json=payload, timeout=timeout)
         return response
     except Exception as e:
-        logger.error(
+        logger.exception(
             f"Error while requesting {url}: {e}"
             f"; request timeout set to {timeout} secs"
         )
-        raise e
+        raise
 
 
 @cache_memoize(60 * 60)
@@ -112,10 +112,7 @@ def fetch_metadata(name):
         response.raise_for_status()
         return response.json()
     except Exception as e:
-        logger.error(
-            f"Error fetching metadata for {name} from {url}: {e}"
-            f"; response body: {response.json()}"
-        )
+        logger.exception(f"Error fetching metadata for {name} from {url}: {e}")
         raise
 
 

--- a/app/enquiries/tests/test_dh_integration.py
+++ b/app/enquiries/tests/test_dh_integration.py
@@ -143,10 +143,7 @@ class DataHubIntegrationTests(TestCase):
             f"Error fetching metadata for {metadata_name} from {url}"
             in message for message in log.output
         )
-        assert any(
-            f"; response body: {response_json}"
-            in message for message in log.output
-        )
+        assert any("Traceback" in message for message in log.output)
 
     def test_dh_request_raises_error(self):
         url = settings.DATA_HUB_COMPANY_SEARCH_URL
@@ -166,6 +163,7 @@ class DataHubIntegrationTests(TestCase):
             f"; request timeout set to {timeout} secs"
             in message for message in log.output
         )
+        assert any("Traceback" in message for message in log.output)
 
     @mock.patch("requests.post")
     def test_dh_request_timeout(self, mock_post):


### PR DESCRIPTION
## Description of change

#987 added exception logging to some functions, however, it was deemed more useful to also log the traceback when an exception occurs.

This PR adds such functionality. It also fixes a bug introduced in the aforementioned PR, that references the variable `response` in an `except` block, where it is out of scope.

## Test instructions

You should now see the traceback logged when an exception occurs during the sending of requests to Data Hub.