### PR TITLE
Dependencies 31-07-2024

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,14 @@
       "dependencies": {
         "govuk-frontend": "^5.4.0",
         "jquery": "^3.7.1",
-        "sass": "^1.77.6"
+        "sass": "^1.77.8"
       },
       "devDependencies": {
         "cypress": "11.2.0",
         "date-fns": "^2.30.0"
+      },
+      "engines": {
+        "node": "20.11"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1749,9 +1752,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.77.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
-      "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -3390,9 +3393,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.77.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
-      "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "^5.4.0",
+        "govuk-frontend": "^5.4.1",
         "jquery": "^3.7.1",
         "sass": "^1.77.8"
       },
@@ -1012,9 +1012,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
-      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.1.tgz",
+      "integrity": "sha512-Gmd8LV++TRh9OF6tA+9KQTpwvlsLcri7qRjViz9ji4YuwZvX+c9TD7tyE+dnJcqsQsJfhr9Fp38m3Hu3H7EIcQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -2848,9 +2848,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
-      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.1.tgz",
+      "integrity": "sha512-Gmd8LV++TRh9OF6tA+9KQTpwvlsLcri7qRjViz9ji4YuwZvX+c9TD7tyE+dnJcqsQsJfhr9Fp38m3Hu3H7EIcQ=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "govuk-frontend": "^5.4.0",
     "jquery": "^3.7.1",
-    "sass": "^1.77.6"
+    "sass": "^1.77.8"
   },
   "devDependencies": {
     "cypress": "11.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/uktrade/enquiry-mgmt-tool#readme",
   "dependencies": {
-    "govuk-frontend": "^5.4.0",
+    "govuk-frontend": "^5.4.1",
     "jquery": "^3.7.1",
     "sass": "^1.77.8"
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ pycparser==2.22
 Pygments==2.18.0
 PyJWT==2.8.0
 pyparsing==3.1.2
-pytest==8.2.2
+pytest==8.3.2
 pytest-cov==5.0.0
 pytest-django==4.8.0
 pytest-freezegun==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ requests-hawk==1.2.1
 requests-mock==1.12.1
 sentry-sdk==2.11.0
 six==1.16.0
-sqlparse==0.5.0
+sqlparse==0.5.1
 traitlets==5.14.3
 uritemplate==4.1.1
 urllib3==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ chardet==5.2.0
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==7.5.4
-cryptography==42.0.8
+cryptography==43.0.0
 dbt-copilot-python==0.2.1
 decorator==5.1.1
 dj-database-url

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cffi==1.16.0
 chardet==5.2.0
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==7.5.4
+coverage==7.6.0
 cryptography==43.0.0
 dbt-copilot-python==0.2.1
 decorator==5.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ django-extensions==3.2.3
 django-filter==24.2
 django-log-formatter-asim==0.0.5
 django-redis==5.4.0
-django-rest-knox==4.2.0
+django-rest-knox==5.0.1
 django-staff-sso-client==4.3.0
 djangorestframework==3.15.2
 djangorestframework-csv==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-cache-memoize==0.2.0
 django-environ==0.11.2
 django-extensions==3.2.3
 django-filter==24.2
-django-log-formatter-asim==0.0.4
+django-log-formatter-asim==0.0.5
 django-redis==5.4.0
 django-rest-knox==4.2.0
 django-staff-sso-client==4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ redis==5.0.7
 requests==2.32.3
 requests-hawk==1.2.1
 requests-mock==1.12.1
-sentry-sdk==2.8.0
+sentry-sdk==2.11.0
 six==1.16.0
 sqlparse==0.5.0
 traitlets==5.14.3


### PR DESCRIPTION
## Description of change

As it says on the tin.

Dependabot also raised #995 to bump Django to 5.x, however, given that we are not using Django 5.x within Data Hub, I told it to ignore future 5.x updates (this can be reverted by reopening the PR).

## Test instructions

You should be able to run EMT as normal and all tests should pass.