### PR TITLE
Dependencies 01-08-2024

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ redis==5.0.8
 requests==2.32.3
 requests-hawk==1.2.1
 requests-mock==1.12.1
-sentry-sdk==2.11.0
+sentry-sdk==2.12.0
 six==1.16.0
 sqlparse==0.5.1
 traitlets==5.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ pytest-cov==5.0.0
 pytest-django==4.8.0
 pytest-freezegun==0.4.2
 pytz==2024.1
-redis==5.0.7
+redis==5.0.8
 requests==2.32.3
 requests-hawk==1.2.1
 requests-mock==1.12.1


### PR DESCRIPTION
## Description of change

As it says on the tin. These Dependabot PR's were raised after #1002 was merged in.

## Test instructions

You should be able to run EMT as normal and all tests should pass.