### PR TITLE
Compatibility changes required to bump Django to 5.0.x

### DIFF
--- a/app/enquiries/admin.py
+++ b/app/enquiries/admin.py
@@ -18,11 +18,11 @@ class OwnerAdmin(admin.ModelAdmin):
     list_display = all_fields_of(Owner, ("password",))
 
 
+@admin.display(
+    description="Enquirer",
+)
 def enquirer(obj):
     return f"{obj.enquirer.first_name} {obj.enquirer.last_name}"
-
-
-enquirer.short_description = "Enquirer"
 
 
 @admin.register(Enquiry)

--- a/app/enquiries/auth.py
+++ b/app/enquiries/auth.py
@@ -37,7 +37,7 @@ class HawkAuthentication(BaseAuthentication):
         If we cannot authenticate, AuthenticationFailed is raised, as required
         in the DRF authentication flow
         """
-        if "HTTP_AUTHORIZATION" not in request.META:
+        if "authorization" not in request.headers:
             raise AuthenticationFailed(NO_CREDENTIALS_MESSAGE)
 
         try:
@@ -128,7 +128,7 @@ def _authorise(request):
     """Raises a HawkFail if the passed request cannot be authenticated"""
     return Receiver(
         _lookup_credentials,
-        request.META["HTTP_AUTHORIZATION"],
+        request.headers["authorization"],
         request.build_absolute_uri(),
         request.method,
         content=request.body,
@@ -180,12 +180,12 @@ class PaaSIPAuthentication(BaseAuthentication):
             logger.warning("PaaS IP check authentication is disabled.")
             return None
 
-        if "HTTP_X_FORWARDED_FOR" not in request.META:
+        if "x-forwarded-for" not in request.headers:
             # We assume that absence of the header indicates connection originating
             # in the internal network
             return None
 
-        x_forwarded_for = request.META["HTTP_X_FORWARDED_FOR"]
+        x_forwarded_for = request.headers["x-forwarded-for"]
         ip_addresses = x_forwarded_for.split(",")
 
         if len(ip_addresses) < settings.AUTH_PAAS_ADDED_X_FORWARDED_FOR_IPS:

--- a/app/enquiries/migrations/0005_auto_20200323_1901.py
+++ b/app/enquiries/migrations/0005_auto_20200323_1901.py
@@ -5,7 +5,6 @@ import django.contrib.auth.models
 import django.contrib.auth.validators
 from django.db import migrations, models
 import django.utils.timezone
-from django.utils.timezone import utc
 
 
 class Migration(migrations.Migration):
@@ -89,7 +88,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='owner',
             name='username',
-            field=models.CharField(default=datetime.datetime(2020, 3, 23, 19, 1, 33, 723242, tzinfo=utc), error_messages={'unique': 'A user with that username already exists.'}, help_text='Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.', max_length=150, unique=True, validators=[django.contrib.auth.validators.UnicodeUsernameValidator()], verbose_name='username'),
+            field=models.CharField(default=datetime.datetime(2020, 3, 23, 19, 1, 33, 723242, tzinfo=datetime.timezone.utc), error_messages={'unique': 'A user with that username already exists.'}, help_text='Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.', max_length=150, unique=True, validators=[django.contrib.auth.validators.UnicodeUsernameValidator()], verbose_name='username'),
             preserve_default=False,
         ),
     ]

--- a/app/settings/common.py
+++ b/app/settings/common.py
@@ -208,7 +208,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   app:
     build: .


### PR DESCRIPTION
## Description of change

This PR originally bumped Django from `4.2.14` to `5.0.8`. However, after some discussion it was decided to stay on `4.2.x` until `5.2.x` is released. Instead of letting this PR go stale, we decided to merge in any compatible changes (with `4.2.x`) now in an attempt to reduce work in the future.

> [!IMPORTANT]
> This PR does NOT bump Django to `5.0.x`

The main changes include:

- Rewrite imports of `django.utils.timezone.utc` to use `datetime.timezone.utc` as Django alias has been deprecated
- Remove deprecated `USE_L10N` setting
- Use admin decorators where `from django.contrib import admin` is used
- Rewrite use of `request.META` to read HTTP headers to instead use `request.headers`

Lastly, I removed the deprecated version key in docker-compose files as Docker kept warning me about these.

## Test instructions

All tests should pass as usual.