### PR TITLE
Add time to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "00:00"
     open-pull-requests-limit: 10
     ignore:
     - dependency-name: sphinx
@@ -16,6 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "01:00"
     open-pull-requests-limit: 10
     ignore:
     - dependency-name: cypress

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,0 @@
----
-applications:
-- buildpacks:
-    - https://github.com/cloudfoundry/python-buildpack.git#v1.8.14
-    - nodejs_buildpack
-  stack: cflinuxfs4


### PR DESCRIPTION
## Description of change

Previously the Dependabot PRs for this repo were being opened at strange times during the evening, and not at midnight in line with our other services. I've set a time for these PRs to be opened so these issues should no longer occur.