### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       time: "00:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     ignore:
     - dependency-name: sphinx
       versions:
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: "weekly"
       time: "01:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     ignore:
     - dependency-name: cypress
       versions:


### PR DESCRIPTION
## Description of change

As this service is currently offline pending retirement there's no point in having the usual Dependabot PRs coming through and wasting CircleCI resources